### PR TITLE
Handle `begin transaction` error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-/target
+**/target
+examples/**/Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "esrs"
-version = "0.5.4"
+version = "0.5.5"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 edition = "2018"

--- a/src/esrs/postgres/mod.rs
+++ b/src/esrs/postgres/mod.rs
@@ -127,7 +127,7 @@ impl<
     /// Begin a new transaction. Commit returned transaction or Drop will automatically rollback it
     pub async fn begin(&self) -> Result<PoolConnection<Postgres>, sqlx::Error> {
         let mut connection = self.pool.acquire().await?;
-        let _ = sqlx::query("BEGIN").execute(&mut connection).await;
+        let _ = sqlx::query("BEGIN").execute(&mut connection).await?;
         Ok(connection)
     }
 

--- a/src/esrs/sqlite/mod.rs
+++ b/src/esrs/sqlite/mod.rs
@@ -122,7 +122,7 @@ impl<
     /// Begin a new transaction. Commit returned transaction or Drop will automatically rollback it
     pub async fn begin(&self) -> Result<PoolConnection<Sqlite>, sqlx::Error> {
         let mut connection = self.pool.acquire().await?;
-        let _ = sqlx::query("BEGIN").execute(&mut connection).await;
+        let _ = sqlx::query("BEGIN").execute(&mut connection).await?;
         Ok(connection)
     }
 


### PR DESCRIPTION
Currently, `begin` in both `postgres` & `sqlite` event store swallows the error if executing `BEGIN` fails.  This could potentially lead to occasions where further execution statements could be running outside of a transaction.