### PR TITLE
[PG-172]: add 'simpler' aggregate trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,7 +254,7 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "esrs"
-version = "0.5.5"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,7 +254,7 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "esrs"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "esrs"
-version = "0.5.5"
+version = "0.6.0"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 edition = "2018"

--- a/examples/postgres_payments.rs
+++ b/examples/postgres_payments.rs
@@ -1,7 +1,7 @@
 use sqlx::{Pool, Postgres};
 use uuid::Uuid;
 
-use esrs::aggregate::{Aggregate, AggregateState};
+use esrs::aggregate::{AggregateManager, AggregateState};
 use postgres_payments::bank_account::aggregate::BankAccountAggregate;
 use postgres_payments::bank_account::command::BankAccountCommand;
 use postgres_payments::bank_account::state::BankAccountState;

--- a/examples/postgres_payments/src/bank_account/aggregate.rs
+++ b/examples/postgres_payments/src/bank_account/aggregate.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use sqlx::{Pool, Postgres};
 use uuid::Uuid;
 
-use esrs::aggregate::{Aggregate, AggregateState, Eraser, Identifier};
+use esrs::aggregate::{AggregateManager, AggregateState, Eraser, Identifier};
 use esrs::projector::PgProjectorEraser;
 use esrs::store::{EraserStore, EventStore, PgStore, StoreEvent};
 
@@ -53,7 +53,7 @@ impl Eraser<BankAccountEvent, BankAccountError> for BankAccountAggregate {
 }
 
 #[async_trait]
-impl Aggregate for BankAccountAggregate {
+impl AggregateManager for BankAccountAggregate {
     type State = BankAccountState;
     type Command = BankAccountCommand;
     type Event = BankAccountEvent;

--- a/examples/postgres_payments/src/credit_card/aggregate.rs
+++ b/examples/postgres_payments/src/credit_card/aggregate.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use sqlx::{Pool, Postgres};
 use uuid::Uuid;
 
-use esrs::aggregate::{Aggregate, AggregateState, Identifier};
+use esrs::aggregate::{AggregateManager, AggregateState, Identifier};
 use esrs::policy::PgPolicy;
 use esrs::projector::PgProjector;
 use esrs::store::{EventStore, PgStore, StoreEvent};
@@ -47,7 +47,7 @@ impl Identifier for CreditCardAggregate {
 }
 
 #[async_trait]
-impl Aggregate for CreditCardAggregate {
+impl AggregateManager for CreditCardAggregate {
     type State = CreditCardState;
     type Command = CreditCardCommand;
     type Event = CreditCardEvent;

--- a/examples/postgres_payments/src/credit_card/aggregate.rs
+++ b/examples/postgres_payments/src/credit_card/aggregate.rs
@@ -3,7 +3,7 @@ use sqlx::{Pool, Postgres};
 use esrs::aggregate::{Aggregate, AggregateState, Identifier};
 use esrs::policy::PgPolicy;
 use esrs::projector::PgProjector;
-use esrs::store::{EventStore, PgStore, StoreEvent};
+use esrs::store::{EventStore, PgStore};
 
 use crate::credit_card::command::CreditCardCommand;
 use crate::credit_card::error::CreditCardError;
@@ -55,8 +55,8 @@ impl Aggregate for CreditCardAggregate {
     }
 
     // No state for credit_card aggregate
-    fn apply_event(state: CreditCardState, event: &StoreEvent<Self::Event>) -> CreditCardState {
-        match event.payload() {
+    fn apply_event(state: CreditCardState, event: &Self::Event) -> CreditCardState {
+        match event {
             CreditCardEvent::Payed { amount } => state.add_amount(*amount),
             CreditCardEvent::Refunded { amount } => state.sub_amount(*amount),
         }

--- a/examples/postgres_payments/src/credit_card/policy.rs
+++ b/examples/postgres_payments/src/credit_card/policy.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use sqlx::{Pool, Postgres};
 
-use esrs::aggregate::{Aggregate, AggregateState};
+use esrs::aggregate::{AggregateManager, AggregateState};
 use esrs::policy::PgPolicy;
 use esrs::store::StoreEvent;
 

--- a/examples/postgres_payments/tests/credit_card_test.rs
+++ b/examples/postgres_payments/tests/credit_card_test.rs
@@ -2,7 +2,7 @@ use sqlx::pool::PoolOptions;
 use sqlx::{Pool, Postgres};
 use uuid::Uuid;
 
-use esrs::aggregate::{Aggregate, AggregateState};
+use esrs::aggregate::{AggregateManager, AggregateState};
 use postgres_payments::bank_account::aggregate::BankAccountAggregate;
 use postgres_payments::bank_account::command::BankAccountCommand;
 use postgres_payments::bank_account::error::BankAccountError;

--- a/examples/postgres_payments/tests/delete_bank_account_test.rs
+++ b/examples/postgres_payments/tests/delete_bank_account_test.rs
@@ -2,7 +2,7 @@ use sqlx::pool::PoolOptions;
 use sqlx::{Pool, Postgres};
 use uuid::Uuid;
 
-use esrs::aggregate::{Aggregate, AggregateState, Eraser};
+use esrs::aggregate::{AggregateManager, AggregateState, Eraser};
 use postgres_payments::bank_account::aggregate::BankAccountAggregate;
 use postgres_payments::bank_account::command::BankAccountCommand;
 use postgres_payments::bank_account::projector::BankAccount;

--- a/examples/postgres_payments/tests/order_test.rs
+++ b/examples/postgres_payments/tests/order_test.rs
@@ -3,7 +3,7 @@ use sqlx::pool::PoolOptions;
 use sqlx::{Pool, Postgres};
 use uuid::Uuid;
 
-use esrs::aggregate::{Aggregate, AggregateState};
+use esrs::aggregate::{AggregateManager, AggregateState};
 use postgres_payments::bank_account::aggregate::BankAccountAggregate;
 use postgres_payments::bank_account::command::BankAccountCommand;
 use postgres_payments::bank_account::state::BankAccountState;

--- a/examples/sqlite_payments.rs
+++ b/examples/sqlite_payments.rs
@@ -2,7 +2,7 @@ use sqlx::pool::PoolOptions;
 use sqlx::{Pool, Sqlite};
 use uuid::Uuid;
 
-use esrs::aggregate::{Aggregate, AggregateState};
+use esrs::aggregate::{AggregateManager, AggregateState};
 use sqlite_payments::bank_account::aggregate::BankAccountAggregate;
 use sqlite_payments::bank_account::command::BankAccountCommand;
 use sqlite_payments::bank_account::state::BankAccountState;

--- a/examples/sqlite_payments/src/bank_account/aggregate.rs
+++ b/examples/sqlite_payments/src/bank_account/aggregate.rs
@@ -2,9 +2,9 @@ use async_trait::async_trait;
 use sqlx::{Pool, Sqlite};
 use uuid::Uuid;
 
-use esrs::aggregate::{AggregateManager, AggregateState, Eraser, Identifier};
+use esrs::aggregate::{Aggregate, AggregateState, Eraser, Identifier};
 use esrs::projector::SqliteProjectorEraser;
-use esrs::store::{EraserStore, EventStore, SqliteStore, StoreEvent};
+use esrs::store::{EraserStore, EventStore, SqliteStore};
 
 use crate::bank_account::command::BankAccountCommand;
 use crate::bank_account::error::BankAccountError;
@@ -52,8 +52,7 @@ impl Eraser<BankAccountEvent, BankAccountError> for BankAccountAggregate {
     }
 }
 
-#[async_trait]
-impl AggregateManager for BankAccountAggregate {
+impl Aggregate for BankAccountAggregate {
     type State = BankAccountState;
     type Command = BankAccountCommand;
     type Event = BankAccountEvent;
@@ -63,8 +62,8 @@ impl AggregateManager for BankAccountAggregate {
         &self.event_store
     }
 
-    fn apply_event(_id: &Uuid, state: BankAccountState, event: &StoreEvent<Self::Event>) -> BankAccountState {
-        match event.payload() {
+    fn apply_event(state: BankAccountState, event: &Self::Event) -> BankAccountState {
+        match event {
             BankAccountEvent::Withdrawn { amount } => state.sub_amount(*amount),
             BankAccountEvent::Deposited { amount } => state.add_amount(*amount),
         }
@@ -85,20 +84,10 @@ impl AggregateManager for BankAccountAggregate {
         }
     }
 
-    async fn do_handle_command(
-        &self,
-        aggregate_state: AggregateState<BankAccountState>,
-        cmd: Self::Command,
-    ) -> Result<AggregateState<Self::State>, Self::Error> {
+    fn handle_command(&self, _aggregate_state: &AggregateState<BankAccountState>, cmd: Self::Command) -> Self::Event {
         match cmd {
-            BankAccountCommand::Withdraw { amount } => {
-                self.persist(aggregate_state, BankAccountEvent::Withdrawn { amount })
-                    .await
-            }
-            BankAccountCommand::Deposit { amount } => {
-                self.persist(aggregate_state, BankAccountEvent::Deposited { amount })
-                    .await
-            }
+            BankAccountCommand::Withdraw { amount } => BankAccountEvent::Withdrawn { amount },
+            BankAccountCommand::Deposit { amount } => BankAccountEvent::Deposited { amount },
         }
     }
 }

--- a/examples/sqlite_payments/src/bank_account/aggregate.rs
+++ b/examples/sqlite_payments/src/bank_account/aggregate.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use sqlx::{Pool, Sqlite};
 use uuid::Uuid;
 
-use esrs::aggregate::{Aggregate, AggregateState, Eraser, Identifier};
+use esrs::aggregate::{AggregateManager, AggregateState, Eraser, Identifier};
 use esrs::projector::SqliteProjectorEraser;
 use esrs::store::{EraserStore, EventStore, SqliteStore, StoreEvent};
 
@@ -53,7 +53,7 @@ impl Eraser<BankAccountEvent, BankAccountError> for BankAccountAggregate {
 }
 
 #[async_trait]
-impl Aggregate for BankAccountAggregate {
+impl AggregateManager for BankAccountAggregate {
     type State = BankAccountState;
     type Command = BankAccountCommand;
     type Event = BankAccountEvent;

--- a/examples/sqlite_payments/src/credit_card/aggregate.rs
+++ b/examples/sqlite_payments/src/credit_card/aggregate.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use sqlx::{Pool, Sqlite};
 use uuid::Uuid;
 
-use esrs::aggregate::{Aggregate, AggregateState, Identifier};
+use esrs::aggregate::{AggregateManager, AggregateState, Identifier};
 use esrs::policy::SqlitePolicy;
 use esrs::projector::SqliteProjector;
 use esrs::store::{EventStore, SqliteStore, StoreEvent};
@@ -47,7 +47,7 @@ impl Identifier for CreditCardAggregate {
 }
 
 #[async_trait]
-impl Aggregate for CreditCardAggregate {
+impl AggregateManager for CreditCardAggregate {
     type State = CreditCardState;
     type Command = CreditCardCommand;
     type Event = CreditCardEvent;

--- a/examples/sqlite_payments/src/credit_card/policy.rs
+++ b/examples/sqlite_payments/src/credit_card/policy.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use sqlx::{Pool, Sqlite};
 
-use esrs::aggregate::{Aggregate, AggregateState};
+use esrs::aggregate::{AggregateManager, AggregateState};
 use esrs::policy::SqlitePolicy;
 use esrs::store::StoreEvent;
 

--- a/examples/sqlite_payments/tests/credit_card_test.rs
+++ b/examples/sqlite_payments/tests/credit_card_test.rs
@@ -2,7 +2,7 @@ use sqlx::pool::PoolOptions;
 use sqlx::{Pool, Sqlite};
 use uuid::Uuid;
 
-use esrs::aggregate::{Aggregate, AggregateState};
+use esrs::aggregate::{AggregateManager, AggregateState};
 use sqlite_payments::bank_account::aggregate::BankAccountAggregate;
 use sqlite_payments::bank_account::command::BankAccountCommand;
 use sqlite_payments::bank_account::error::BankAccountError;

--- a/examples/sqlite_payments/tests/delete_bank_account_test.rs
+++ b/examples/sqlite_payments/tests/delete_bank_account_test.rs
@@ -2,7 +2,7 @@ use sqlx::pool::PoolOptions;
 use sqlx::{Pool, Sqlite};
 use uuid::Uuid;
 
-use esrs::aggregate::{Aggregate, AggregateState, Eraser};
+use esrs::aggregate::{AggregateManager, AggregateState, Eraser};
 use sqlite_payments::bank_account::aggregate::BankAccountAggregate;
 use sqlite_payments::bank_account::command::BankAccountCommand;
 use sqlite_payments::bank_account::projector::BankAccount;

--- a/src/esrs/aggregate.rs
+++ b/src/esrs/aggregate.rs
@@ -129,7 +129,7 @@ pub trait Aggregate {
     fn event_store(&self) -> &(dyn EventStore<Self::Event, Self::Error> + Send + Sync);
 
     /// Updates the aggregate state using the new event.
-    fn apply_event(state: Self::State, event: &StoreEvent<Self::Event>) -> Self::State;
+    fn apply_event(state: Self::State, event: &Self::Event) -> Self::State;
 
     /// Validates a command against the current aggregate state.  The aggregate must be able to handle the command
     /// if validation succeeds.
@@ -153,7 +153,7 @@ impl<T: Aggregate + Sync + Identifier> AggregateManager for T {
     }
 
     fn apply_event(_id: &Uuid, state: Self::State, event: &StoreEvent<Self::Event>) -> Self::State {
-        T::apply_event(state, event)
+        T::apply_event(state, event.payload())
     }
 
     fn validate_command(aggregate_state: &AggregateState<Self::State>, cmd: &Self::Command) -> Result<(), Self::Error> {
@@ -176,61 +176,5 @@ impl<T: Aggregate + Sync + Identifier> AggregateManager for T {
     ) -> Result<AggregateState<Self::State>, Self::Error> {
         Self::validate_command(&aggregate_state, &cmd)?;
         AggregateManager::do_handle_command(self, aggregate_state, cmd).await
-    }
-
-    fn apply_events(
-        aggregate_state: AggregateState<Self::State>,
-        events: Vec<StoreEvent<Self::Event>>,
-    ) -> AggregateState<Self::State> {
-        let mut max_seq_number: SequenceNumber = 0;
-
-        let inner: Self::State = events.iter().fold(
-            aggregate_state.inner,
-            |acc: Self::State, event: &StoreEvent<Self::Event>| {
-                if event.sequence_number() > max_seq_number {
-                    max_seq_number = event.sequence_number()
-                }
-                Self::apply_event(acc, event)
-            },
-        );
-
-        AggregateState {
-            inner,
-            sequence_number: max_seq_number,
-            ..aggregate_state
-        }
-    }
-
-    async fn load(&self, aggregate_id: Uuid) -> Option<AggregateState<Self::State>> {
-        let events: Vec<StoreEvent<Self::Event>> = self
-            .event_store()
-            .by_aggregate_id(aggregate_id)
-            .await
-            .ok()?
-            .into_iter()
-            .collect();
-
-        if events.is_empty() {
-            None
-        } else {
-            Some(Self::apply_events(AggregateState::new(aggregate_id), events))
-        }
-    }
-
-    async fn persist(
-        &self,
-        aggregate_state: AggregateState<Self::State>,
-        event: Self::Event,
-    ) -> Result<AggregateState<Self::State>, Self::Error> {
-        let next_sequence_number: SequenceNumber = aggregate_state.sequence_number + 1;
-        Ok(self
-            .event_store()
-            .persist(aggregate_state.id, event, next_sequence_number)
-            .await
-            .map(|event| AggregateState {
-                inner: Self::apply_event(aggregate_state.inner, &event),
-                sequence_number: next_sequence_number,
-                ..aggregate_state
-            })?)
     }
 }

--- a/src/esrs/aggregate.rs
+++ b/src/esrs/aggregate.rs
@@ -115,3 +115,122 @@ pub trait AggregateManager: Identifier {
             })?)
     }
 }
+
+/// Aggregate trait.
+/// An Aggregate is responsible for validating commands, mapping commands to events, and
+/// mapping commands to events.
+pub trait Aggregate {
+    type State: Default + Clone + Debug + Send + Sync;
+    type Command: Send + Sync;
+    type Event: Serialize + DeserializeOwned + Send + Sync;
+    type Error: Send + Sync;
+
+    /// Event store configured for aggregate
+    fn event_store(&self) -> &(dyn EventStore<Self::Event, Self::Error> + Send + Sync);
+
+    /// Updates the aggregate state using the new event.
+    fn apply_event(state: Self::State, event: &StoreEvent<Self::Event>) -> Self::State;
+
+    /// Validates a command against the current aggregate state.  The aggregate must be able to handle the command
+    /// if validation succeeds.
+    fn validate_command(aggregate_state: &AggregateState<Self::State>, cmd: &Self::Command) -> Result<(), Self::Error>;
+
+    /// Handles a validated command, and emits a single event.
+    fn handle_command(&self, aggregate_state: &AggregateState<Self::State>, cmd: Self::Command) -> Self::Event;
+}
+
+#[async_trait]
+impl<T: Aggregate + Sync + Identifier> AggregateManager for T {
+    type State = T::State;
+    type Command = T::Command;
+    type Event = T::Event;
+    type Error = T::Error;
+
+    /// Event store configured for aggregate
+    // TODO: should this even be a method on the aggregate?
+    fn event_store(&self) -> &(dyn EventStore<Self::Event, Self::Error> + Send + Sync) {
+        self.event_store()
+    }
+
+    fn apply_event(_id: &Uuid, state: Self::State, event: &StoreEvent<Self::Event>) -> Self::State {
+        T::apply_event(state, event)
+    }
+
+    fn validate_command(aggregate_state: &AggregateState<Self::State>, cmd: &Self::Command) -> Result<(), Self::Error> {
+        T::validate_command(aggregate_state, cmd)
+    }
+
+    async fn do_handle_command(
+        &self,
+        aggregate_state: AggregateState<Self::State>,
+        cmd: Self::Command,
+    ) -> Result<AggregateState<T::State>, T::Error> {
+        let event = Aggregate::handle_command(self, &aggregate_state, cmd);
+        AggregateManager::persist(self, aggregate_state, event).await
+    }
+
+    async fn handle_command(
+        &self,
+        aggregate_state: AggregateState<Self::State>,
+        cmd: Self::Command,
+    ) -> Result<AggregateState<Self::State>, Self::Error> {
+        Self::validate_command(&aggregate_state, &cmd)?;
+        AggregateManager::do_handle_command(self, aggregate_state, cmd).await
+    }
+
+    fn apply_events(
+        aggregate_state: AggregateState<Self::State>,
+        events: Vec<StoreEvent<Self::Event>>,
+    ) -> AggregateState<Self::State> {
+        let mut max_seq_number: SequenceNumber = 0;
+
+        let inner: Self::State = events.iter().fold(
+            aggregate_state.inner,
+            |acc: Self::State, event: &StoreEvent<Self::Event>| {
+                if event.sequence_number() > max_seq_number {
+                    max_seq_number = event.sequence_number()
+                }
+                Self::apply_event(acc, event)
+            },
+        );
+
+        AggregateState {
+            inner,
+            sequence_number: max_seq_number,
+            ..aggregate_state
+        }
+    }
+
+    async fn load(&self, aggregate_id: Uuid) -> Option<AggregateState<Self::State>> {
+        let events: Vec<StoreEvent<Self::Event>> = self
+            .event_store()
+            .by_aggregate_id(aggregate_id)
+            .await
+            .ok()?
+            .into_iter()
+            .collect();
+
+        if events.is_empty() {
+            None
+        } else {
+            Some(Self::apply_events(AggregateState::new(aggregate_id), events))
+        }
+    }
+
+    async fn persist(
+        &self,
+        aggregate_state: AggregateState<Self::State>,
+        event: Self::Event,
+    ) -> Result<AggregateState<Self::State>, Self::Error> {
+        let next_sequence_number: SequenceNumber = aggregate_state.sequence_number + 1;
+        Ok(self
+            .event_store()
+            .persist(aggregate_state.id, event, next_sequence_number)
+            .await
+            .map(|event| AggregateState {
+                inner: Self::apply_event(aggregate_state.inner, &event),
+                sequence_number: next_sequence_number,
+                ..aggregate_state
+            })?)
+    }
+}

--- a/src/esrs/aggregate.rs
+++ b/src/esrs/aggregate.rs
@@ -25,9 +25,11 @@ pub trait Eraser<
     async fn delete(&self, aggregate_id: Uuid) -> Result<(), Error>;
 }
 
-/// Aggregate trait. It is used to keep the state in-memory and to validate commands. It also persist events
+/// AggregateManager trait.
+/// An AggregateManager is responsible for loading an aggregate from the store, mapping commands to events, and
+/// persisting those events in the store.
 #[async_trait]
-pub trait Aggregate: Identifier {
+pub trait AggregateManager: Identifier {
     type State: Default + Clone + Debug + Send + Sync;
     type Command: Send + Sync;
     type Event: Serialize + DeserializeOwned + Send + Sync;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 mod esrs;
 
 pub mod aggregate {
-    pub use crate::esrs::aggregate::{Aggregate, Eraser, Identifier};
+    pub use crate::esrs::aggregate::{AggregateManager, Eraser, Identifier};
     pub use crate::esrs::state::AggregateState;
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 mod esrs;
 
 pub mod aggregate {
-    pub use crate::esrs::aggregate::{AggregateManager, Eraser, Identifier};
+    pub use crate::esrs::aggregate::{Aggregate, AggregateManager, Eraser, Identifier};
     pub use crate::esrs::state::AggregateState;
 }
 


### PR DESCRIPTION
https://prima-assicurazioni-spa.myjetbrains.com/youtrack/issue/PG-172

closes #68

Renames `Aggregate` to `AggregateManager` and introduces a new, simplified `Aggregate` trait.  The aim is to reduce the implementation complexity of aggregates for the majority of use-cases (ie _pure aggregates_).

There is a default implementation of `AggregateManager` for `Aggregate` - so that implementors of the `Aggregate` trait get the correct 'pipelining' behaviour for free.

demo tracking branch of [platform-global](https://github.com/primait/platform-global/pull/86)

#69 is in progress - but was getting rather large so wanted to split this out first