### PR TITLE
add examples crates to workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ categories = ["rust-patterns", "web-programming", "asynchronous", "data-structur
 keywords = ["architecture", "ddd", "event-sourcing", "cqrs", "es"]
 authors = ["Simone Cottini <cottini.simone@gmail.com>"]
 
+[workspace]
+members = ["examples/postgres_payments", "examples/sqlite_payments"]
+
 [[example]]
 name = "postgres-payments"
 path = "examples/postgres_payments.rs"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,6 +1,9 @@
 [env.drone]
 DATABASE_URL = "postgresql://postgres:postgres@postgres:5432/postgres"
 
+[config]
+default_to_workspace = false
+
 [tasks.build-ci]
 description = "Build prima_tracing.rs inside CI."
 command = "cargo"
@@ -14,7 +17,7 @@ args = ["fmt", "--all", "--", "--check"]
 [tasks.test]
 description = "Run tests."
 command = "cargo"
-args = ["test", "${@}"]
+args = ["test", "${@}", "--all"]
 
 [tasks.clippy-ci]
 command = "cargo"


### PR DESCRIPTION
makes tests under `examples/` run as part of ci