### PR TITLE
 [PG-172]: transactionally emit/persist multiple events from handling command

### DIFF
--- a/examples/postgres_payments/src/bank_account/aggregate.rs
+++ b/examples/postgres_payments/src/bank_account/aggregate.rs
@@ -92,11 +92,11 @@ impl AggregateManager for BankAccountAggregate {
     ) -> Result<AggregateState<Self::State>, Self::Error> {
         match cmd {
             BankAccountCommand::Withdraw { amount } => {
-                self.persist(aggregate_state, BankAccountEvent::Withdrawn { amount })
+                self.persist(aggregate_state, vec![BankAccountEvent::Withdrawn { amount }])
                     .await
             }
             BankAccountCommand::Deposit { amount } => {
-                self.persist(aggregate_state, BankAccountEvent::Deposited { amount })
+                self.persist(aggregate_state, vec![BankAccountEvent::Deposited { amount }])
                     .await
             }
         }

--- a/examples/postgres_payments/src/credit_card/aggregate.rs
+++ b/examples/postgres_payments/src/credit_card/aggregate.rs
@@ -82,10 +82,14 @@ impl Aggregate for CreditCardAggregate {
         }
     }
 
-    fn handle_command(&self, _aggregate_state: &AggregateState<CreditCardState>, cmd: Self::Command) -> Self::Event {
+    fn handle_command(
+        &self,
+        _aggregate_state: &AggregateState<CreditCardState>,
+        cmd: Self::Command,
+    ) -> Vec<Self::Event> {
         match cmd {
-            CreditCardCommand::Pay { amount } => CreditCardEvent::Payed { amount },
-            CreditCardCommand::Refund { amount } => CreditCardEvent::Refunded { amount },
+            CreditCardCommand::Pay { amount } => vec![CreditCardEvent::Payed { amount }],
+            CreditCardCommand::Refund { amount } => vec![CreditCardEvent::Refunded { amount }],
         }
     }
 }

--- a/examples/sqlite_payments/src/bank_account/aggregate.rs
+++ b/examples/sqlite_payments/src/bank_account/aggregate.rs
@@ -84,10 +84,14 @@ impl Aggregate for BankAccountAggregate {
         }
     }
 
-    fn handle_command(&self, _aggregate_state: &AggregateState<BankAccountState>, cmd: Self::Command) -> Self::Event {
+    fn handle_command(
+        &self,
+        _aggregate_state: &AggregateState<BankAccountState>,
+        cmd: Self::Command,
+    ) -> Vec<Self::Event> {
         match cmd {
-            BankAccountCommand::Withdraw { amount } => BankAccountEvent::Withdrawn { amount },
-            BankAccountCommand::Deposit { amount } => BankAccountEvent::Deposited { amount },
+            BankAccountCommand::Withdraw { amount } => vec![BankAccountEvent::Withdrawn { amount }],
+            BankAccountCommand::Deposit { amount } => vec![BankAccountEvent::Deposited { amount }],
         }
     }
 }

--- a/examples/sqlite_payments/src/credit_card/aggregate.rs
+++ b/examples/sqlite_payments/src/credit_card/aggregate.rs
@@ -91,9 +91,12 @@ impl AggregateManager for CreditCardAggregate {
         cmd: Self::Command,
     ) -> Result<AggregateState<Self::State>, Self::Error> {
         match cmd {
-            CreditCardCommand::Pay { amount } => self.persist(aggregate_state, CreditCardEvent::Payed { amount }).await,
+            CreditCardCommand::Pay { amount } => {
+                self.persist(aggregate_state, vec![CreditCardEvent::Payed { amount }])
+                    .await
+            }
             CreditCardCommand::Refund { amount } => {
-                self.persist(aggregate_state, CreditCardEvent::Refunded { amount })
+                self.persist(aggregate_state, vec![CreditCardEvent::Refunded { amount }])
                     .await
             }
         }

--- a/src/esrs/aggregate.rs
+++ b/src/esrs/aggregate.rs
@@ -73,27 +73,22 @@ pub trait AggregateManager: Identifier {
     }
 
     /// Responsible for applying events in order onto the aggregate state, and incrementing the sequence number.
-    /// You should avoid implenting this method, and be _very_ careful if you decide to do so.
+    /// You should avoid implementing this method, and be _very_ careful if you decide to do so.
+    ///
+    /// `events` will be passed in order of ascending sequence number.
     fn apply_events(
         aggregate_state: AggregateState<Self::State>,
         events: Vec<StoreEvent<Self::Event>>,
     ) -> AggregateState<Self::State> {
-        let mut max_seq_number: SequenceNumber = 0;
-
         let aggregate_id: &Uuid = &aggregate_state.id;
         let inner: Self::State = events.iter().fold(
             aggregate_state.inner,
-            |acc: Self::State, event: &StoreEvent<Self::Event>| {
-                if event.sequence_number() > max_seq_number {
-                    max_seq_number = event.sequence_number()
-                }
-                Self::apply_event(aggregate_id, acc, event)
-            },
+            |acc: Self::State, event: &StoreEvent<Self::Event>| Self::apply_event(aggregate_id, acc, event),
         );
 
         AggregateState {
             inner,
-            sequence_number: max_seq_number,
+            sequence_number: events.last().map_or(0, |e| e.sequence_number()),
             ..aggregate_state
         }
     }
@@ -120,12 +115,12 @@ pub trait AggregateManager: Identifier {
     async fn persist(
         &self,
         aggregate_state: AggregateState<Self::State>,
-        event: Self::Event,
+        events: Vec<Self::Event>,
     ) -> Result<AggregateState<Self::State>, Self::Error> {
         let next_sequence_number: SequenceNumber = aggregate_state.sequence_number + 1;
         let events = self
             .event_store()
-            .persist(aggregate_state.id, vec![event], next_sequence_number)
+            .persist(aggregate_state.id, events, next_sequence_number)
             .await?;
 
         Ok(Self::apply_events(aggregate_state, events))
@@ -160,8 +155,8 @@ pub trait Aggregate {
     /// if validation succeeds.
     fn validate_command(aggregate_state: &AggregateState<Self::State>, cmd: &Self::Command) -> Result<(), Self::Error>;
 
-    /// Handles a validated command, and emits a single event.
-    fn handle_command(&self, aggregate_state: &AggregateState<Self::State>, cmd: Self::Command) -> Self::Event;
+    /// Handles a validated command, and emits events.
+    fn handle_command(&self, aggregate_state: &AggregateState<Self::State>, cmd: Self::Command) -> Vec<Self::Event>;
 }
 
 #[async_trait]
@@ -188,8 +183,8 @@ impl<T: Aggregate + Sync + Identifier> AggregateManager for T {
         aggregate_state: AggregateState<Self::State>,
         cmd: Self::Command,
     ) -> Result<AggregateState<T::State>, T::Error> {
-        let event = Aggregate::handle_command(self, &aggregate_state, cmd);
-        AggregateManager::persist(self, aggregate_state, event).await
+        let events = Aggregate::handle_command(self, &aggregate_state, cmd);
+        AggregateManager::persist(self, aggregate_state, events).await
     }
 
     async fn handle_command(

--- a/src/esrs/aggregate.rs
+++ b/src/esrs/aggregate.rs
@@ -123,15 +123,12 @@ pub trait AggregateManager: Identifier {
         event: Self::Event,
     ) -> Result<AggregateState<Self::State>, Self::Error> {
         let next_sequence_number: SequenceNumber = aggregate_state.sequence_number + 1;
-        Ok(self
+        let events = self
             .event_store()
-            .persist(aggregate_state.id, event, next_sequence_number)
-            .await
-            .map(|event| AggregateState {
-                inner: Self::apply_event(&aggregate_state.id, aggregate_state.inner, &event),
-                sequence_number: next_sequence_number,
-                ..aggregate_state
-            })?)
+            .persist(aggregate_state.id, vec![event], next_sequence_number)
+            .await?;
+
+        Ok(Self::apply_events(aggregate_state, events))
     }
 }
 

--- a/src/esrs/sqlite/mod.rs
+++ b/src/esrs/sqlite/mod.rs
@@ -10,7 +10,6 @@ use futures::TryStreamExt;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use sqlx::pool::{PoolConnection, PoolOptions};
-use sqlx::sqlite::SqliteQueryResult;
 use sqlx::{Pool, Sqlite};
 use uuid::Uuid;
 
@@ -174,55 +173,66 @@ impl<
     async fn persist(
         &self,
         aggregate_id: Uuid,
-        event: Evt,
-        sequence_number: SequenceNumber,
-    ) -> Result<StoreEvent<Evt>, Err> {
+        events: Vec<Evt>,
+        starting_sequence_number: SequenceNumber,
+    ) -> Result<Vec<StoreEvent<Evt>>, Err> {
         let mut connection: PoolConnection<Sqlite> = self.begin().await?;
 
-        let event_id: Uuid = Uuid::new_v4();
         let occurred_on: DateTime<Utc> = Utc::now();
-        let store_event_result: Result<SqliteQueryResult, Err> = sqlx::query(self.queries.insert())
-            .bind(event_id)
-            .bind(aggregate_id)
-            .bind(Json(&event))
-            .bind(occurred_on)
-            .bind(sequence_number)
-            .execute(&mut *connection)
-            .await
-            .map_err(|error| error.into());
 
-        let rebuild_result: Result<StoreEvent<Evt>, Err> = match store_event_result {
-            Ok(_) => {
-                let store_event: StoreEvent<Evt> = StoreEvent {
-                    id: event_id,
-                    aggregate_id,
-                    payload: event,
-                    occurred_on,
-                    sequence_number,
-                };
+        let events: Vec<_> = events
+            .into_iter()
+            .map(|e| (Uuid::new_v4(), e))
+            .zip(starting_sequence_number..)
+            .collect();
 
-                self.project_event(&store_event, &mut connection)
-                    .await
-                    .map(|()| store_event)
-            }
-            Err(error) => Err(error),
-        };
+        for ((event_id, event), sequence_number) in events.iter() {
+            let result = sqlx::query(self.queries.insert())
+                .bind(event_id)
+                .bind(aggregate_id)
+                .bind(Json(event))
+                .bind(occurred_on)
+                .bind(sequence_number)
+                .execute(&mut *connection)
+                .await;
 
-        match rebuild_result {
-            Ok(event) => {
-                self.commit(connection).await?;
-
-                for policy in &self.policies {
-                    policy.handle_event(&event, &self.pool).await?
-                }
-
-                Ok(event)
-            }
-            Err(err) => {
+            if let Err(err) = result {
                 self.rollback(connection).await?;
-                Err(err)
+                return Err(err.into());
             }
         }
+
+        let store_events: Vec<_> = events
+            .into_iter()
+            .map(|((event_id, event), sequence_number)| StoreEvent {
+                id: event_id,
+                aggregate_id,
+                payload: event,
+                occurred_on,
+                sequence_number,
+            })
+            .collect();
+
+        for store_event in store_events.iter() {
+            let result = self.project_event(store_event, &mut connection).await;
+
+            if let Err(err) = result {
+                self.rollback(connection).await?;
+                return Err(err);
+            }
+        }
+
+        self.commit(connection).await?;
+
+        // REVIEW: This implies that potentially half of the policies would trigger, then one fails, and the rest wouldn't.
+        // potentially we should be returning some other kind of error, that includes the errors from any failed policies?
+        for policy in &self.policies {
+            for store_event in store_events.iter() {
+                policy.handle_event(store_event, &self.pool).await?
+            }
+        }
+
+        Ok(store_events)
     }
 
     async fn close(&self) {

--- a/src/esrs/store.rs
+++ b/src/esrs/store.rs
@@ -16,9 +16,9 @@ pub trait EventStore<Event: Serialize + DeserializeOwned + Send + Sync, Error> {
     async fn persist(
         &self,
         aggregate_id: Uuid,
-        event: Event,
-        sequence_number: SequenceNumber,
-    ) -> Result<StoreEvent<Event>, Error>;
+        _events: Vec<Event>,
+        starting_sequence_number: SequenceNumber,
+    ) -> Result<Vec<StoreEvent<Event>>, Error>;
 
     async fn close(&self);
 }


### PR DESCRIPTION
https://prima-assicurazioni-spa.myjetbrains.com/youtrack/issue/PG-172

closes #69

persist multiple events inside a single transaction & update `Aggregate` trait to return `Vec<Event>` from `handle_command`