### PR TITLE
split up policies from persist

### DIFF
--- a/src/esrs/aggregate.rs
+++ b/src/esrs/aggregate.rs
@@ -188,13 +188,4 @@ impl<T: Aggregate + Sync + Identifier> AggregateManager for T {
         let events = Aggregate::handle_command(self, &aggregate_state, cmd);
         AggregateManager::persist(self, aggregate_state, events).await
     }
-
-    async fn handle_command(
-        &self,
-        aggregate_state: AggregateState<Self::State>,
-        cmd: Self::Command,
-    ) -> Result<AggregateState<Self::State>, Self::Error> {
-        Self::validate_command(&aggregate_state, &cmd)?;
-        AggregateManager::do_handle_command(self, aggregate_state, cmd).await
-    }
 }

--- a/src/esrs/aggregate.rs
+++ b/src/esrs/aggregate.rs
@@ -123,6 +123,8 @@ pub trait AggregateManager: Identifier {
             .persist(aggregate_state.id, events, next_sequence_number)
             .await?;
 
+        self.event_store().run_policies(&events).await?;
+
         Ok(Self::apply_events(aggregate_state, events))
     }
 }

--- a/src/esrs/aggregate.rs
+++ b/src/esrs/aggregate.rs
@@ -7,7 +7,6 @@ use uuid::Uuid;
 
 use crate::esrs::state::AggregateState;
 use crate::esrs::store::{EventStore, StoreEvent};
-use crate::esrs::SequenceNumber;
 
 /// The Identifier trait is responsible for naming an aggregate type.
 /// Each aggregate type should have an identifier that is unique among all the aggregate types in your application.
@@ -117,10 +116,9 @@ pub trait AggregateManager: Identifier {
         aggregate_state: AggregateState<Self::State>,
         events: Vec<Self::Event>,
     ) -> Result<AggregateState<Self::State>, Self::Error> {
-        let next_sequence_number: SequenceNumber = aggregate_state.sequence_number + 1;
         let events = self
             .event_store()
-            .persist(aggregate_state.id, events, next_sequence_number)
+            .persist(aggregate_state.id, events, aggregate_state.next_sequence_number())
             .await?;
 
         self.event_store().run_policies(&events).await?;

--- a/src/esrs/postgres/mod.rs
+++ b/src/esrs/postgres/mod.rs
@@ -229,15 +229,20 @@ impl<
 
         self.commit(connection).await?;
 
-        // REVIEW: This implies that potentially half of the policies would trigger, then one fails, and the rest wouldn't.
+        Ok(store_events)
+    }
+
+    /// Default `run_policies` strategy is to run all events against each policy in turn, returning on the first error.
+    async fn run_policies(&self, events: &[StoreEvent<Evt>]) -> Result<(), Err> {
+        // TODO: This implies that potentially half of the policies would trigger, then one fails, and the rest wouldn't.
         // potentially we should be returning some other kind of error, that includes the errors from any failed policies?
         for policy in &self.policies {
-            for store_event in store_events.iter() {
-                policy.handle_event(store_event, &self.pool).await?
+            for event in events.iter() {
+                policy.handle_event(event, &self.pool).await?
             }
         }
 
-        Ok(store_events)
+        Ok(())
     }
 
     async fn close(&self) {

--- a/src/esrs/state.rs
+++ b/src/esrs/state.rs
@@ -46,4 +46,8 @@ impl<S: Default + Debug + Clone> AggregateState<S> {
     pub fn inner(&self) -> &S {
         &self.inner
     }
+
+    pub fn next_sequence_number(&self) -> SequenceNumber {
+        self.sequence_number + 1
+    }
 }

--- a/src/esrs/store.rs
+++ b/src/esrs/store.rs
@@ -19,13 +19,17 @@ pub trait EventStore<Event: Serialize + DeserializeOwned + Send + Sync, Error> {
     /// Persists multiple events into the database.  This should be done transactionally - either
     /// all the events are persisted correctly, or none are.
     ///
-    /// Persisting events may additionally trigger configured Policies or Projectors.
+    /// Persisting events may additionally trigger configured Projectors.
     async fn persist(
         &self,
         aggregate_id: Uuid,
         events: Vec<Event>,
         starting_sequence_number: SequenceNumber,
     ) -> Result<Vec<StoreEvent<Event>>, Error>;
+
+    /// Run any policies attached to this store against a set of events.
+    /// This should be called only after the events have successfully been persisted in the store.
+    async fn run_policies(&self, events: &[StoreEvent<Event>]) -> Result<(), Error>;
 
     async fn close(&self);
 }


### PR DESCRIPTION
closes #81 

Runs policies after the event store `persist` has run.  Provided a consumer of this crate _does not implement_ `AggregateManager` directly, the change is a backwards compatible one.

It does, however, allow the behaviour to be overrided - so that an error in a policy would not result in `handle_command` itself returning an error, for example.