### PR TITLE
lock inside state

### DIFF
--- a/examples/customize_persistence_flow/src/aggregate.rs
+++ b/examples/customize_persistence_flow/src/aggregate.rs
@@ -59,7 +59,7 @@ impl AggregateManager for CounterAggregate {
 
     async fn store_events(
         &self,
-        aggregate_state: &AggregateState<Self::State>,
+        aggregate_state: &mut AggregateState<Self::State>,
         events: Vec<Self::Event>,
     ) -> Result<Vec<StoreEvent<Self::Event>>, Self::Error> {
         // Here is the persistence flow customization.
@@ -89,6 +89,11 @@ impl AggregateManager for CounterAggregate {
                         projector.project(store_event, &mut connection).await?;
                     }
                 }
+
+                // We need to drop the lock on the aggregate state here as:
+                // 1. the events have already been persisted, hence the DB has the latest aggregate;
+                // 2. the policies below might need to access this aggregate atomically (causing a deadlock!).
+                drop(aggregate_state.take_lock());
 
                 for store_event in store_events.iter() {
                     for policy in self.event_store.policies().iter() {

--- a/examples/customize_persistence_flow/src/aggregate.rs
+++ b/examples/customize_persistence_flow/src/aggregate.rs
@@ -84,8 +84,10 @@ impl AggregateManager for CounterAggregate {
                     )
                 }
 
+                // Acquiring the list of projectors early, as it is an expensive operation.
+                let projectors = self.event_store().projectors();
                 for store_event in store_events.iter() {
-                    for projector in self.event_store.projectors().iter() {
+                    for projector in projectors.iter() {
                         projector.project(store_event, &mut connection).await?;
                     }
                 }
@@ -95,8 +97,10 @@ impl AggregateManager for CounterAggregate {
                 // 2. the policies below might need to access this aggregate atomically (causing a deadlock!).
                 drop(aggregate_state.take_lock());
 
+                // Acquiring the list of policies early, as it is an expensive operation.
+                let policies = self.event_store().policies();
                 for store_event in store_events.iter() {
-                    for policy in self.event_store.policies().iter() {
+                    for policy in policies.iter() {
                         // We want to just log errors instead of return them. This is the customization
                         // we wanted.
                         match policy.handle_event(store_event).await {

--- a/examples/locking_strategies/src/lib.rs
+++ b/examples/locking_strategies/src/lib.rs
@@ -8,7 +8,7 @@ use delete_aggregate::structs::CounterError;
 /// Increment the value behind this `aggregate_id` as soon as atomical access can be obtained.
 /// The lock can be obtained even if there are current optimistic accesses! Avoid mixing the two strategies when writing.
 pub async fn increment_atomically(aggregate: CounterAggregate, aggregate_id: Uuid) -> Result<(), CounterError> {
-    let aggregate_state = aggregate.lock_and_load(aggregate_id).await.unwrap_or_default();
+    let aggregate_state = aggregate.lock_and_load(aggregate_id).await?.unwrap_or_default();
     aggregate
         .handle_command(aggregate_state, CounterCommand::Increment)
         .await?;
@@ -19,7 +19,7 @@ pub async fn increment_atomically(aggregate: CounterAggregate, aggregate_id: Uui
 /// Optimistic access ignores any current active lock! Avoid mixing the two strategies when writing.
 pub async fn increment_optimistically(aggregate: CounterAggregate, aggregate_id: Uuid) -> Result<(), CounterError> {
     // Every optimistic access can take place concurrently...
-    let aggregate_state = aggregate.load(aggregate_id).await.unwrap_or_default();
+    let aggregate_state = aggregate.load(aggregate_id).await?.unwrap_or_default();
     // ...and events are persisted in non-deterministic order.
     // This could raise optimistic locking errors, that must be handled downstream.
     aggregate
@@ -32,7 +32,7 @@ pub async fn increment_optimistically(aggregate: CounterAggregate, aggregate_id:
 /// Avoid using atomic reads if writes are optimistic, as the state would be modified anyway!
 /// If writes are atomic, it is perfectly fine to use a mixture of atomic and optimistic reads.
 pub async fn with_atomic_read(aggregate: CounterAggregate, aggregate_id: Uuid) -> Result<(), CounterError> {
-    let aggregate_state = aggregate.lock_and_load(aggregate_id).await.unwrap_or_default();
+    let aggregate_state = aggregate.lock_and_load(aggregate_id).await?.unwrap_or_default();
     // No one else (employing locking!) can read or modify the state just loaded here,
     // ensuring this really is the *latest* aggregate state.
     println!(
@@ -47,7 +47,7 @@ pub async fn with_atomic_read(aggregate: CounterAggregate, aggregate_id: Uuid) -
 /// Otherwise, optimistic reads are allowed: beware there are no guarantees the state loaded is actually the latest.
 pub async fn with_optimistic_read(aggregate: CounterAggregate, aggregate_id: Uuid) -> Result<(), CounterError> {
     // Read the state now, ignoring any explicit locking...
-    let aggregate_state = aggregate.load(aggregate_id).await.unwrap_or_default();
+    let aggregate_state = aggregate.load(aggregate_id).await?.unwrap_or_default();
     // ...but nothing prevents something else from updating the data in the store in the meanwhile,
     // so the `aggregate_state` here might be already outdated at this point.
     println!(

--- a/examples/simple_saga/src/lib.rs
+++ b/examples/simple_saga/src/lib.rs
@@ -95,8 +95,8 @@ impl Policy<LoggingAggregate> for LoggingPolicy {
         let aggregate_state: AggregateState<u64> = self
             .aggregate
             .load(aggregate_id)
-            .await
-            .unwrap_or_else(|| AggregateState::new(aggregate_id)); // This should never happen
+            .await?
+            .unwrap_or_else(|| AggregateState::with_id(aggregate_id)); // This should never happen
 
         if let LoggingEvent::Received(msg) = event.payload() {
             if msg.contains("fail_policy") {

--- a/src/esrs/aggregate.rs
+++ b/src/esrs/aggregate.rs
@@ -72,11 +72,10 @@ pub trait AggregateManager: Aggregate {
         &self,
         mut aggregate_state: AggregateState<Self::State>,
         command: Self::Command,
-    ) -> Result<AggregateState<Self::State>, Self::Error> {
+    ) -> Result<(), Self::Error> {
         let events: Vec<Self::Event> = <Self as Aggregate>::handle_command(aggregate_state.inner(), command)?;
-        let stored_events: Vec<StoreEvent<Self::Event>> = self.store_events(&mut aggregate_state, events).await?;
-
-        Ok(aggregate_state.apply_store_events(stored_events, Self::apply_event))
+        self.store_events(&mut aggregate_state, events).await?;
+        Ok(())
     }
 
     /// Loads an aggregate instance from the event store, by applying previously persisted events onto

--- a/src/esrs/aggregate.rs
+++ b/src/esrs/aggregate.rs
@@ -1,7 +1,6 @@
 use async_trait::async_trait;
 use uuid::Uuid;
 
-use crate::types::SequenceNumber;
 use crate::{AggregateState, EventStore, StoreEvent};
 
 /// The Aggregate trait is responsible for validating commands, mapping commands to events, and applying
@@ -43,14 +42,6 @@ pub trait Aggregate {
     ///
     /// If this is not the case, this function is allowed to panic.
     fn apply_event(state: Self::State, payload: Self::Event) -> Self::State;
-
-    /// Updates the aggregate state using the list of new events. Take a look to
-    /// [`Aggregate::apply_event`] for further information.
-    fn apply_events(state: Self::State, events: Vec<Self::Event>) -> Self::State {
-        events.into_iter().fold(state, |acc: Self::State, event: Self::Event| {
-            Self::apply_event(acc, event)
-        })
-    }
 }
 
 /// The AggregateManager is responsible for coupling the Aggregate with a Store, so that the events
@@ -85,57 +76,32 @@ pub trait AggregateManager: Aggregate {
         let events: Vec<Self::Event> = <Self as Aggregate>::handle_command(aggregate_state.inner(), command)?;
         let stored_events: Vec<StoreEvent<Self::Event>> = self.store_events(&mut aggregate_state, events).await?;
 
-        Ok(<Self as AggregateManager>::apply_events(aggregate_state, stored_events))
-    }
-
-    /// Responsible for applying events in order onto the aggregate state, and incrementing the sequence number.
-    ///
-    /// `events` will be passed in order of ascending sequence number.
-    ///
-    /// You should _avoid_ implementing this function, and be _very_ careful if you decide to do so.
-    fn apply_events(
-        aggregate_state: AggregateState<Self::State>,
-        store_events: Vec<StoreEvent<Self::Event>>,
-    ) -> AggregateState<Self::State> {
-        let sequence_number: SequenceNumber = store_events.last().map_or(0, StoreEvent::sequence_number);
-
-        let events: Vec<Self::Event> = store_events
-            .into_iter()
-            .map(|store_event| store_event.payload)
-            .collect();
-
-        let inner: Self::State = <Self as Aggregate>::apply_events(aggregate_state.inner, events);
-
-        AggregateState {
-            sequence_number,
-            inner,
-            ..aggregate_state
-        }
+        Ok(aggregate_state.apply_store_events(stored_events, Self::apply_event))
     }
 
     /// Loads an aggregate instance from the event store, by applying previously persisted events onto
     /// the aggregate state by order of their sequence number
     ///
     /// You should _avoid_ implementing this function, and be _very_ careful if you decide to do so.
-    async fn load(&self, aggregate_id: impl Into<Uuid> + Send) -> Option<AggregateState<Self::State>> {
+    async fn load(
+        &self,
+        aggregate_id: impl Into<Uuid> + Send,
+    ) -> Result<Option<AggregateState<Self::State>>, Self::Error> {
         let aggregate_id: Uuid = aggregate_id.into();
 
-        let events: Vec<StoreEvent<Self::Event>> = self
+        let store_events: Vec<StoreEvent<Self::Event>> = self
             .event_store()
             .by_aggregate_id(aggregate_id)
-            .await
-            .ok()?
+            .await?
             .into_iter()
             .collect();
 
-        if events.is_empty() {
+        Ok(if store_events.is_empty() {
             None
         } else {
-            Some(<Self as AggregateManager>::apply_events(
-                AggregateState::new(aggregate_id),
-                events,
-            ))
-        }
+            let aggregate_state = AggregateState::with_id(aggregate_id);
+            Some(aggregate_state.apply_store_events(store_events, Self::apply_event))
+        })
     }
 
     /// Acquires a lock on this aggregate instance, and only then loads it from the event store,
@@ -145,15 +111,17 @@ pub trait AggregateManager: Aggregate {
     /// It can also be extracted with the `take_lock` method for more advanced uses.
     ///
     /// You should _avoid_ implementing this function, and be _very_ careful if you decide to do so.
-    async fn lock_and_load(&self, aggregate_id: impl Into<Uuid> + Send) -> Option<AggregateState<Self::State>> {
+    async fn lock_and_load(
+        &self,
+        aggregate_id: impl Into<Uuid> + Send,
+    ) -> Result<Option<AggregateState<Self::State>>, Self::Error> {
         let id = aggregate_id.into();
-        let Ok(guard) = self.event_store().lock(id).await else {
-            return None;
-        };
-        self.load(id).await.map(|mut state| {
+        let guard = self.event_store().lock(id).await?;
+
+        Ok(self.load(id).await?.map(|mut state| {
             state.set_lock(guard);
             state
-        })
+        }))
     }
 
     /// Transactional persists events in store - recording it in the aggregate instance's history.

--- a/src/esrs/postgres/tests/mod.rs
+++ b/src/esrs/postgres/tests/mod.rs
@@ -98,7 +98,7 @@ fn persist_single_event_test(pool: Pool<Postgres>) {
 
     assert_eq!(store_event[0].aggregate_id, aggregate_id);
     assert_eq!(store_event[0].payload.id, event_internal_id);
-    assert_eq!(store_event[0].sequence_number, 0);
+    assert_eq!(store_event[0].sequence_number, 1);
 
     let store_events: Vec<StoreEvent<TestEvent>> = store.by_aggregate_id(aggregate_id).await.unwrap();
     assert_eq!(store_events.len(), 1);
@@ -124,10 +124,10 @@ fn persist_multiple_events_test(pool: Pool<Postgres>) {
     assert_eq!(store_event.len(), 2);
     assert_eq!(store_event[0].aggregate_id, aggregate_id);
     assert_eq!(store_event[0].payload.id, test_event_1.id);
-    assert_eq!(store_event[0].sequence_number, 0);
+    assert_eq!(store_event[0].sequence_number, 1);
     assert_eq!(store_event[1].aggregate_id, aggregate_id);
     assert_eq!(store_event[1].payload.id, test_event_2.id);
-    assert_eq!(store_event[1].sequence_number, 1);
+    assert_eq!(store_event[1].sequence_number, 2);
 
     let store_events: Vec<StoreEvent<TestEvent>> = store.by_aggregate_id(aggregate_id).await.unwrap();
     assert_eq!(store_events.len(), 2);

--- a/src/esrs/postgres/tests/mod.rs
+++ b/src/esrs/postgres/tests/mod.rs
@@ -87,10 +87,10 @@ fn by_aggregate_id_insert_and_delete_by_aggregate_id_test(pool: Pool<Postgres>) 
 fn persist_single_event_test(pool: Pool<Postgres>) {
     let store: PgStore<TestAggregate> = PgStore::new(pool.clone()).setup().await.unwrap();
 
-    let event_internal_id: Uuid = Uuid::new_v4();
-    let aggregate_id: Uuid = Uuid::new_v4();
-    let mut aggregate_state = AggregateState::<()>::new(aggregate_id);
+    let mut aggregate_state = AggregateState::new();
+    let aggregate_id = *aggregate_state.id();
 
+    let event_internal_id: Uuid = Uuid::new_v4();
     let store_event: Vec<StoreEvent<TestEvent>> =
         EventStore::persist(&store, &mut aggregate_state, vec![TestEvent { id: event_internal_id }])
             .await
@@ -110,8 +110,8 @@ fn persist_multiple_events_test(pool: Pool<Postgres>) {
 
     let test_event_1: TestEvent = TestEvent { id: Uuid::new_v4() };
     let test_event_2: TestEvent = TestEvent { id: Uuid::new_v4() };
-    let aggregate_id: Uuid = Uuid::new_v4();
-    let mut aggregate_state = AggregateState::<()>::new(aggregate_id);
+    let mut aggregate_state = AggregateState::new();
+    let aggregate_id = *aggregate_state.id();
 
     let store_event: Vec<StoreEvent<TestEvent>> = EventStore::persist(
         &store,
@@ -144,8 +144,8 @@ fn event_projection_test(pool: Pool<Postgres>) {
     create_test_projection_table(&pool).await;
 
     let event_internal_id: Uuid = Uuid::new_v4();
-    let aggregate_id: Uuid = Uuid::new_v4();
-    let mut aggregate_state = AggregateState::<()>::new(aggregate_id);
+    let mut aggregate_state = AggregateState::new();
+    let aggregate_id = *aggregate_state.id();
 
     let _store_event: Vec<StoreEvent<TestEvent>> =
         EventStore::persist(&store, &mut aggregate_state, vec![TestEvent { id: event_internal_id }])
@@ -173,8 +173,8 @@ fn delete_store_events_and_projections_test(pool: Pool<Postgres>) {
     create_test_projection_table(&pool).await;
 
     let event_internal_id: Uuid = Uuid::new_v4();
-    let aggregate_id: Uuid = Uuid::new_v4();
-    let mut aggregate_state = AggregateState::<()>::new(aggregate_id);
+    let mut aggregate_state = AggregateState::new();
+    let aggregate_id = *aggregate_state.id();
 
     let _store_event: Vec<StoreEvent<TestEvent>> =
         EventStore::persist(&store, &mut aggregate_state, vec![TestEvent { id: event_internal_id }])
@@ -220,8 +220,7 @@ fn policy_test(pool: Pool<Postgres>) {
         .unwrap();
 
     let event_internal_id: Uuid = Uuid::new_v4();
-    let aggregate_id: Uuid = Uuid::new_v4();
-    let mut aggregate_state = AggregateState::<()>::new(aggregate_id);
+    let mut aggregate_state = AggregateState::new();
 
     let _store_event: Vec<StoreEvent<TestEvent>> =
         EventStore::persist(&store, &mut aggregate_state, vec![TestEvent { id: event_internal_id }])

--- a/src/esrs/postgres/tests/mod.rs
+++ b/src/esrs/postgres/tests/mod.rs
@@ -6,7 +6,7 @@ use sqlx::{PgConnection, Pool, Postgres};
 use uuid::Uuid;
 
 use crate::postgres::{PgStore, Projector};
-use crate::{Aggregate, AggregateManager, EventStore, Policy, StoreEvent};
+use crate::{Aggregate, AggregateManager, AggregateState, EventStore, Policy, StoreEvent};
 
 #[sqlx::test]
 fn setup_database_test(pool: Pool<Postgres>) {
@@ -89,9 +89,10 @@ fn persist_single_event_test(pool: Pool<Postgres>) {
 
     let event_internal_id: Uuid = Uuid::new_v4();
     let aggregate_id: Uuid = Uuid::new_v4();
+    let mut aggregate_state = AggregateState::<()>::new(aggregate_id);
 
     let store_event: Vec<StoreEvent<TestEvent>> =
-        EventStore::persist(&store, aggregate_id, vec![TestEvent { id: event_internal_id }], 0)
+        EventStore::persist(&store, &mut aggregate_state, vec![TestEvent { id: event_internal_id }])
             .await
             .unwrap();
 
@@ -110,12 +111,12 @@ fn persist_multiple_events_test(pool: Pool<Postgres>) {
     let test_event_1: TestEvent = TestEvent { id: Uuid::new_v4() };
     let test_event_2: TestEvent = TestEvent { id: Uuid::new_v4() };
     let aggregate_id: Uuid = Uuid::new_v4();
+    let mut aggregate_state = AggregateState::<()>::new(aggregate_id);
 
     let store_event: Vec<StoreEvent<TestEvent>> = EventStore::persist(
         &store,
-        aggregate_id,
+        &mut aggregate_state,
         vec![test_event_1.clone(), test_event_2.clone()],
-        0,
     )
     .await
     .unwrap();
@@ -144,9 +145,10 @@ fn event_projection_test(pool: Pool<Postgres>) {
 
     let event_internal_id: Uuid = Uuid::new_v4();
     let aggregate_id: Uuid = Uuid::new_v4();
+    let mut aggregate_state = AggregateState::<()>::new(aggregate_id);
 
     let _store_event: Vec<StoreEvent<TestEvent>> =
-        EventStore::persist(&store, aggregate_id, vec![TestEvent { id: event_internal_id }], 0)
+        EventStore::persist(&store, &mut aggregate_state, vec![TestEvent { id: event_internal_id }])
             .await
             .unwrap();
 
@@ -172,9 +174,10 @@ fn delete_store_events_and_projections_test(pool: Pool<Postgres>) {
 
     let event_internal_id: Uuid = Uuid::new_v4();
     let aggregate_id: Uuid = Uuid::new_v4();
+    let mut aggregate_state = AggregateState::<()>::new(aggregate_id);
 
     let _store_event: Vec<StoreEvent<TestEvent>> =
-        EventStore::persist(&store, aggregate_id, vec![TestEvent { id: event_internal_id }], 0)
+        EventStore::persist(&store, &mut aggregate_state, vec![TestEvent { id: event_internal_id }])
             .await
             .unwrap();
 
@@ -218,9 +221,10 @@ fn policy_test(pool: Pool<Postgres>) {
 
     let event_internal_id: Uuid = Uuid::new_v4();
     let aggregate_id: Uuid = Uuid::new_v4();
+    let mut aggregate_state = AggregateState::<()>::new(aggregate_id);
 
     let _store_event: Vec<StoreEvent<TestEvent>> =
-        EventStore::persist(&store, aggregate_id, vec![TestEvent { id: event_internal_id }], 0)
+        EventStore::persist(&store, &mut aggregate_state, vec![TestEvent { id: event_internal_id }])
             .await
             .unwrap();
 

--- a/src/esrs/state.rs
+++ b/src/esrs/state.rs
@@ -1,15 +1,41 @@
 use uuid::Uuid;
 
+use crate::esrs::store::EventStoreLockGuard;
 use crate::types::SequenceNumber;
 
 /// The internal state for an Aggregate.
-/// It contains and id representing the aggregate id, an incremental sequence number and a state
-/// defined by the user of this library.
-#[derive(Clone, Debug)]
+/// It contains:
+/// - an id uniquely representing the aggregate,
+/// - an incremental sequence number,
+/// - a lock representing the atomicity of the access to the aggregate,
+/// - a state defined by the user of this library.
 pub struct AggregateState<S> {
     pub(crate) id: Uuid,
     pub(crate) sequence_number: SequenceNumber,
+    pub(crate) lock: Option<EventStoreLockGuard>,
     pub(crate) inner: S,
+}
+
+impl<S: Clone> Clone for AggregateState<S> {
+    fn clone(&self) -> Self {
+        Self {
+            id: self.id,
+            sequence_number: self.sequence_number,
+            inner: self.inner.clone(),
+            lock: None,
+        }
+    }
+}
+
+impl<S: std::fmt::Debug> std::fmt::Debug for AggregateState<S> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AggregateState")
+            .field("id", &self.id)
+            .field("sequence_number", &self.sequence_number)
+            .field("inner", &self.inner)
+            .field("lock", &self.lock.is_some())
+            .finish()
+    }
 }
 
 /// Default implementation for [`AggregateState`]
@@ -25,21 +51,21 @@ impl<S: Default> AggregateState<S> {
     /// might happen.
     ///
     /// Prefer [Default] implementation.
-    #[must_use]
     pub fn new(id: impl Into<Uuid>) -> Self {
         Self {
             id: id.into(),
             inner: Default::default(),
             sequence_number: 0,
+            lock: None,
         }
     }
 
-    /// Returns an Uuid representing the aggregate id
+    /// Returns an Uuid representing the aggregate id.
     pub const fn id(&self) -> &Uuid {
         &self.id
     }
 
-    /// Returns the internal state
+    /// Returns the internal state.
     pub const fn inner(&self) -> &S {
         &self.inner
     }
@@ -47,5 +73,15 @@ impl<S: Default> AggregateState<S> {
     /// Returns the internal sequence number incremented by 1.
     pub const fn next_sequence_number(&self) -> SequenceNumber {
         self.sequence_number + 1
+    }
+
+    /// Insert the lock guard into self, replacing any current one.
+    pub fn set_lock(&mut self, guard: EventStoreLockGuard) {
+        self.lock = Some(guard);
+    }
+
+    /// Extract the lock from self, leaving nothing behind.
+    pub fn take_lock(&mut self) -> Option<EventStoreLockGuard> {
+        self.lock.take()
     }
 }

--- a/src/esrs/state.rs
+++ b/src/esrs/state.rs
@@ -1,6 +1,7 @@
 use uuid::Uuid;
 
 use crate::esrs::store::EventStoreLockGuard;
+use crate::esrs::store::StoreEvent;
 use crate::types::SequenceNumber;
 
 /// The internal state for an Aggregate.
@@ -10,21 +11,10 @@ use crate::types::SequenceNumber;
 /// - a lock representing the atomicity of the access to the aggregate,
 /// - a state defined by the user of this library.
 pub struct AggregateState<S> {
-    pub(crate) id: Uuid,
-    pub(crate) sequence_number: SequenceNumber,
-    pub(crate) lock: Option<EventStoreLockGuard>,
-    pub(crate) inner: S,
-}
-
-impl<S: Clone> Clone for AggregateState<S> {
-    fn clone(&self) -> Self {
-        Self {
-            id: self.id,
-            sequence_number: self.sequence_number,
-            inner: self.inner.clone(),
-            lock: None,
-        }
-    }
+    id: Uuid,
+    sequence_number: SequenceNumber,
+    lock: Option<EventStoreLockGuard>,
+    inner: S,
 }
 
 impl<S: std::fmt::Debug> std::fmt::Debug for AggregateState<S> {
@@ -32,8 +22,8 @@ impl<S: std::fmt::Debug> std::fmt::Debug for AggregateState<S> {
         f.debug_struct("AggregateState")
             .field("id", &self.id)
             .field("sequence_number", &self.sequence_number)
-            .field("inner", &self.inner)
             .field("lock", &self.lock.is_some())
+            .field("inner", &self.inner)
             .finish()
     }
 }
@@ -41,23 +31,53 @@ impl<S: std::fmt::Debug> std::fmt::Debug for AggregateState<S> {
 /// Default implementation for [`AggregateState`]
 impl<S: Default> Default for AggregateState<S> {
     fn default() -> Self {
-        Self::new(Uuid::new_v4())
+        Self::new()
     }
 }
 
 impl<S: Default> AggregateState<S> {
-    /// Creates a new instance of an [`AggregateState`] with the given aggregate id. The use of this
-    /// is discouraged being that that aggregate id could be already existing and a clash of ids
-    /// might happen.
+    /// Creates a new instance of an [`AggregateState`] with a new unique id.
+    pub fn new() -> Self {
+        Self {
+            id: Uuid::new_v4(),
+            inner: Default::default(),
+            sequence_number: 0,
+            lock: None,
+        }
+    }
+
+    /// Creates a new instance of an [`AggregateState`] with the given aggregate id.
     ///
-    /// Prefer [Default] implementation.
-    pub fn new(id: impl Into<Uuid>) -> Self {
+    /// This should be used almost exclusively when loading by aggregate id yields nothing,
+    /// and this becomes the brand new aggregate state for that id.
+    ///
+    /// Other uses are strongly discouraged, since the id could be already existing
+    /// and a clash might happen when persisting events.
+    pub fn with_id(id: impl Into<Uuid>) -> Self {
         Self {
             id: id.into(),
             inner: Default::default(),
             sequence_number: 0,
             lock: None,
         }
+    }
+
+    /// Consumes the aggregate state and generates a new one with the events applied to it,
+    /// as dictaded by `apply_event`.
+    pub fn apply_store_events<T, F>(self, store_events: Vec<StoreEvent<T>>, apply_event: F) -> Self
+    where
+        F: Fn(S, T) -> S,
+    {
+        store_events.into_iter().fold(self, |state, store_event| {
+            let sequence_number = *store_event.sequence_number();
+            let inner = apply_event(state.inner, store_event.payload);
+
+            Self {
+                sequence_number,
+                inner,
+                ..state
+            }
+        })
     }
 
     /// Returns an Uuid representing the aggregate id.
@@ -70,17 +90,27 @@ impl<S: Default> AggregateState<S> {
         &self.inner
     }
 
-    /// Returns the internal sequence number incremented by 1.
-    pub const fn next_sequence_number(&self) -> SequenceNumber {
+    /// Consumes self and extracts the internal state.
+    pub fn into_inner(self) -> S {
+        self.inner
+    }
+
+    /// Returns the internal sequence number.
+    pub const fn sequence_number(&self) -> &SequenceNumber {
+        &self.sequence_number
+    }
+
+    /// Computes the internal sequence number incremented by 1.
+    pub fn next_sequence_number(&self) -> SequenceNumber {
         self.sequence_number + 1
     }
 
-    /// Insert the lock guard into self, replacing any current one.
+    /// Inserts the lock guard into self, replacing any current one.
     pub fn set_lock(&mut self, guard: EventStoreLockGuard) {
         self.lock = Some(guard);
     }
 
-    /// Extract the lock from self, leaving nothing behind.
+    /// Extracts the lock from self, leaving nothing behind.
     pub fn take_lock(&mut self) -> Option<EventStoreLockGuard> {
         self.lock.take()
     }

--- a/src/esrs/store.rs
+++ b/src/esrs/store.rs
@@ -5,12 +5,12 @@ use chrono::{DateTime, Utc};
 use uuid::Uuid;
 
 use crate::types::SequenceNumber;
-use crate::{Aggregate, AggregateManager};
+use crate::{Aggregate, AggregateManager, AggregateState};
 
 /// Marker trait for every EventStoreLockGuard.
 ///
 /// Implementors should unlock concurrent access to the guarded resource, when dropped.
-pub trait UnlockOnDrop: Send + 'static {}
+pub trait UnlockOnDrop: Send + Sync + 'static {}
 
 /// Lock guard preventing concurrent access to a resource.
 ///
@@ -50,9 +50,8 @@ pub trait EventStore {
     /// Persisting events may additionally trigger configured Projectors.
     async fn persist(
         &self,
-        aggregate_id: Uuid,
+        aggregate_state: &mut AggregateState<<Self::Manager as Aggregate>::State>,
         events: Vec<<Self::Manager as Aggregate>::Event>,
-        starting_sequence_number: SequenceNumber,
     ) -> Result<Vec<StoreEvent<<Self::Manager as Aggregate>::Event>>, <Self::Manager as Aggregate>::Error>;
 
     /// Delete all events from events store related to given `aggregate_id`.
@@ -108,13 +107,10 @@ where
 
     async fn persist(
         &self,
-        aggregate_id: Uuid,
+        aggregate_state: &mut AggregateState<<Self::Manager as Aggregate>::State>,
         events: Vec<<Self::Manager as Aggregate>::Event>,
-        starting_sequence_number: SequenceNumber,
     ) -> Result<Vec<StoreEvent<<Self::Manager as Aggregate>::Event>>, <Self::Manager as Aggregate>::Error> {
-        self.deref()
-            .persist(aggregate_id, events, starting_sequence_number)
-            .await
+        self.deref().persist(aggregate_state, events).await
     }
 
     async fn delete(&self, aggregate_id: Uuid) -> Result<(), <Self::Manager as Aggregate>::Error> {

--- a/src/esrs/store.rs
+++ b/src/esrs/store.rs
@@ -134,8 +134,8 @@ pub struct StoreEvent<Event> {
 }
 
 impl<Event> StoreEvent<Event> {
-    pub const fn sequence_number(&self) -> SequenceNumber {
-        self.sequence_number
+    pub const fn sequence_number(&self) -> &SequenceNumber {
+        &self.sequence_number
     }
 
     pub const fn payload(&self) -> &Event {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 pub use crate::esrs::aggregate::{Aggregate, AggregateManager};
 pub use crate::esrs::policy::Policy;
 pub use crate::esrs::state::AggregateState;
-pub use crate::esrs::store::{EventStore, StoreEvent};
+pub use crate::esrs::store::{EventStore, EventStoreLockGuard, StoreEvent, UnlockOnDrop};
 
 mod esrs;
 


### PR DESCRIPTION
In the 0.8.0 release we added the explicit locking mechanism, which turned out to be unsound:
1. you would lock an aggregate, load its state, and handle a command, and only then release the lock
2. **_whilst_** handling command, the event store saves the events, runs the projectors, and runs the policies; but the latter might invoke methods on aggregates (step 1) which could be trying to lock the same resource you are holding (deadlocks!)

In this PR we try to rectify the issue by moving the lock inside the aggregate state, and consume the lock internally after saving the events BUT before running policies.
This also improves the API of AggregateManager, as you don't need to hold a lock guard yourself, rather you just need to `manager.lock_and_load(id).await` which yields until you have managed to obtain exclusive access.

EDIT: I went wild with the last commit, as I heavily changed the API of AggregateState and removed a bunch of "should-not-override" methods from the Aggregate and AggregateManager traits. Fixed some minor "bugs"/issues, see discussion for details.