### PR TITLE
Fix deployment --allow-dirty issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+# Temporary hack to fix the CI until we migrate to github actions from drone.
 .cargo
 **/target
 examples/**/Cargo.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.cargo
 **/target
 examples/**/Cargo.lock
 Cargo.lock


### PR DESCRIPTION
The [build])https://drone-1.prima.it/primait/event_sourcing.rs/451/1/4) that failed because of dirty directory. The issue is that `.cargo` directory should be ignored