### PR TITLE
make the AggregateManager deref blanket implementation work for smart pointers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM public.ecr.aws/prima/rust:1.69.0
+FROM public.ecr.aws/prima/rust:1.75.0
 
 WORKDIR /code
 
 COPY entrypoint /code/entrypoint
 
-RUN cargo install sqlx-cli --no-default-features --features native-tls,postgres --version 0.6.2
+RUN cargo install sqlx-cli --no-default-features --features native-tls,postgres --version 0.7.1
 
 RUN chown -R app:app /code
 

--- a/examples/aggregate_deletion/main.rs
+++ b/examples/aggregate_deletion/main.rs
@@ -9,7 +9,10 @@ use esrs::store::postgres::{PgStore, PgStoreBuilder, PgStoreError};
 use esrs::store::{EventStore, StoreEvent};
 use esrs::AggregateState;
 
-use crate::common::{new_pool, BasicAggregate, BasicCommand, BasicError, BasicEvent, BasicEventHandler, BasicView};
+use crate::common::basic::event_handler::BasicEventHandler;
+use crate::common::basic::view::BasicView;
+use crate::common::basic::{BasicAggregate, BasicCommand, BasicError, BasicEvent};
+use crate::common::util::new_pool;
 
 #[path = "../common/lib.rs"]
 mod common;

--- a/examples/common/basic/event_handler.rs
+++ b/examples/common/basic/event_handler.rs
@@ -5,7 +5,8 @@ use uuid::Uuid;
 use esrs::handler::EventHandler;
 use esrs::store::StoreEvent;
 
-use crate::common::{BasicAggregate, BasicEvent, BasicView};
+use crate::common::basic::view::BasicView;
+use crate::common::basic::{BasicAggregate, BasicEvent};
 
 #[derive(Clone)]
 pub struct BasicEventHandler {

--- a/examples/common/basic/mod.rs
+++ b/examples/common/basic/mod.rs
@@ -1,11 +1,9 @@
 use serde::{Deserialize, Serialize};
 
 use esrs::Aggregate;
-pub use event_handler::*;
-pub use view::*;
 
-mod event_handler;
-mod view;
+pub mod event_handler;
+pub mod view;
 
 #[derive(Clone)]
 pub struct BasicAggregate;

--- a/examples/common/basic/view.rs
+++ b/examples/common/basic/view.rs
@@ -1,7 +1,7 @@
 use sqlx::{Executor, Pool, Postgres};
 use uuid::Uuid;
 
-use crate::common::random_letters;
+use crate::common::util::random_letters;
 
 #[derive(sqlx::FromRow, Debug)]
 pub struct BasicViewRow {

--- a/examples/common/lib.rs
+++ b/examples/common/lib.rs
@@ -1,23 +1,15 @@
 //! Common structs shared between all the other examples
 
-pub use a::*;
-pub use b::*;
+pub mod a;
+pub mod b;
 #[cfg(feature = "postgres")]
-pub use basic::*;
-#[cfg(feature = "postgres")]
-pub use shared::*;
-pub use util::*;
-
-mod a;
-mod b;
-#[cfg(feature = "postgres")]
-mod basic;
+pub mod basic;
 
 #[allow(dead_code)]
 #[cfg(feature = "postgres")]
-mod shared;
+pub mod shared;
 
-mod util;
+pub mod util;
 
 #[derive(Debug, thiserror::Error)]
 pub enum CommonError {}

--- a/examples/common/shared/event_handler.rs
+++ b/examples/common/shared/event_handler.rs
@@ -4,7 +4,9 @@ use sqlx::{Pool, Postgres};
 use esrs::handler::{EventHandler, ReplayableEventHandler};
 use esrs::store::StoreEvent;
 
-use crate::common::{AggregateA, AggregateB, EventA, EventB, SharedView, UpsertSharedView};
+use crate::common::a::{AggregateA, EventA};
+use crate::common::b::{AggregateB, EventB};
+use crate::common::shared::view::{SharedView, UpsertSharedView};
 
 #[derive(Clone)]
 pub struct SharedEventHandler {

--- a/examples/common/shared/mod.rs
+++ b/examples/common/shared/mod.rs
@@ -1,5 +1,2 @@
-pub use event_handler::*;
-pub use view::*;
-
-mod event_handler;
-mod view;
+pub mod event_handler;
+pub mod view;

--- a/examples/common/shared/view.rs
+++ b/examples/common/shared/view.rs
@@ -1,7 +1,7 @@
 use sqlx::{Executor, Pool, Postgres};
 use uuid::Uuid;
 
-use crate::common::random_letters;
+use crate::common::util::random_letters;
 
 #[derive(Clone)]
 pub struct SharedView {

--- a/examples/event_bus/main.rs
+++ b/examples/event_bus/main.rs
@@ -20,7 +20,10 @@ use esrs::manager::AggregateManager;
 use esrs::store::postgres::{PgStore, PgStoreBuilder, PgStoreError};
 use esrs::AggregateState;
 
-use crate::common::{new_pool, random_letters, BasicAggregate, BasicCommand, BasicError, BasicEventHandler, BasicView};
+use crate::common::basic::event_handler::BasicEventHandler;
+use crate::common::basic::view::BasicView;
+use crate::common::basic::{BasicAggregate, BasicCommand, BasicError};
+use crate::common::util::{new_pool, random_letters};
 use crate::kafka::KafkaEventBusConsumer;
 use crate::rabbit::RabbitEventBusConsumer;
 

--- a/examples/event_bus/rabbit.rs
+++ b/examples/event_bus/rabbit.rs
@@ -8,7 +8,7 @@ use esrs::handler::EventHandler;
 use esrs::store::StoreEvent;
 use esrs::Aggregate;
 
-use crate::common::random_letters;
+use crate::common::util::random_letters;
 
 pub struct RabbitEventBusConsumer<A> {
     consumer: Consumer,

--- a/examples/eventual_view/main.rs
+++ b/examples/eventual_view/main.rs
@@ -9,7 +9,10 @@ use esrs::manager::AggregateManager;
 use esrs::store::postgres::{PgStore, PgStoreBuilder, PgStoreError};
 use esrs::AggregateState;
 
-use crate::common::{new_pool, BasicAggregate, BasicCommand, BasicError, BasicEventHandler, BasicView};
+use crate::common::basic::event_handler::BasicEventHandler;
+use crate::common::basic::view::BasicView;
+use crate::common::basic::{BasicAggregate, BasicCommand, BasicError};
+use crate::common::util::new_pool;
 
 #[path = "../common/lib.rs"]
 mod common;

--- a/examples/locking_strategies/main.rs
+++ b/examples/locking_strategies/main.rs
@@ -45,7 +45,8 @@ use esrs::store::postgres::{PgStore, PgStoreBuilder, PgStoreError};
 use esrs::store::EventStore;
 use esrs::AggregateState;
 
-use crate::common::{new_pool, BasicAggregate, BasicCommand, BasicError, BasicEvent};
+use crate::common::basic::{BasicAggregate, BasicCommand, BasicError, BasicEvent};
+use crate::common::util::new_pool;
 
 #[path = "../common/lib.rs"]
 mod common;

--- a/examples/multi_aggregate_rebuild/main.rs
+++ b/examples/multi_aggregate_rebuild/main.rs
@@ -21,9 +21,12 @@ use esrs::store::postgres::{PgStore, PgStoreBuilder, PgStoreError};
 use esrs::store::StoreEvent;
 use esrs::AggregateState;
 
-use crate::common::{
-    new_pool, AggregateA, AggregateB, CommandA, CommandB, CommonError, EventA, EventB, SharedEventHandler, SharedView,
-};
+use crate::common::a::{AggregateA, CommandA, EventA};
+use crate::common::b::{AggregateB, CommandB, EventB};
+use crate::common::shared::event_handler::SharedEventHandler;
+use crate::common::shared::view::SharedView;
+use crate::common::util::new_pool;
+use crate::common::CommonError;
 use crate::transactional_event_handler::SharedTransactionalEventHandler;
 
 #[path = "../common/lib.rs"]

--- a/examples/multi_aggregate_rebuild/transactional_event_handler.rs
+++ b/examples/multi_aggregate_rebuild/transactional_event_handler.rs
@@ -5,7 +5,9 @@ use esrs::handler::TransactionalEventHandler;
 use esrs::store::postgres::PgStoreError;
 use esrs::store::StoreEvent;
 
-use crate::common::{AggregateA, AggregateB, EventA, EventB, SharedView, UpsertSharedView};
+use crate::common::a::{AggregateA, EventA};
+use crate::common::b::{AggregateB, EventB};
+use crate::common::shared::view::{SharedView, UpsertSharedView};
 
 #[derive(Clone)]
 pub struct SharedTransactionalEventHandler {

--- a/examples/readme/main.rs
+++ b/examples/readme/main.rs
@@ -1,17 +1,15 @@
-use sqlx::{PgConnection, Pool, Postgres};
-
 use serde::{Deserialize, Serialize};
+use sqlx::{PgConnection, Pool, Postgres};
+use thiserror::Error;
 
+use esrs::bus::EventBus;
 use esrs::handler::{EventHandler, TransactionalEventHandler};
 use esrs::manager::AggregateManager;
 use esrs::store::postgres::{PgStore, PgStoreBuilder, PgStoreError};
 use esrs::store::StoreEvent;
 use esrs::Aggregate;
 
-use esrs::bus::EventBus;
-use thiserror::Error;
-
-use crate::common::new_pool;
+use crate::common::util::new_pool;
 
 #[path = "../common/lib.rs"]
 mod common;

--- a/examples/rebuilder/event_handler.rs
+++ b/examples/rebuilder/event_handler.rs
@@ -4,11 +4,12 @@ use sqlx::{Pool, Postgres};
 use esrs::handler::{EventHandler, ReplayableEventHandler};
 use esrs::store::StoreEvent;
 
+use crate::common::basic::view::BasicView;
+use crate::common::basic::{BasicAggregate, BasicEvent};
+
 /// This is just an example. The need of v1 and v2 is due to having both the version of this event
 /// handler compiled in the code. In user codebase there will be only one `BasicEventHandler`
 /// got modified.
-use crate::common::{BasicAggregate, BasicEvent, BasicView};
-
 #[derive(Clone)]
 pub struct BasicEventHandlerV1 {
     pub pool: Pool<Postgres>,

--- a/examples/rebuilder/main.rs
+++ b/examples/rebuilder/main.rs
@@ -40,7 +40,9 @@ use esrs::rebuilder::{PgRebuilder, Rebuilder};
 use esrs::store::postgres::{PgStore, PgStoreBuilder, PgStoreError};
 use esrs::AggregateState;
 
-use crate::common::{new_pool, BasicAggregate, BasicCommand, BasicError, BasicView};
+use crate::common::basic::view::BasicView;
+use crate::common::basic::{BasicAggregate, BasicCommand, BasicError};
+use crate::common::util::new_pool;
 use crate::event_handler::{AnotherEventHandler, BasicEventHandlerV1, BasicEventHandlerV2};
 use crate::transactional_event_handler::{BasicTransactionalEventHandlerV1, BasicTransactionalEventHandlerV2};
 

--- a/examples/rebuilder/transactional_event_handler.rs
+++ b/examples/rebuilder/transactional_event_handler.rs
@@ -5,7 +5,8 @@ use esrs::handler::TransactionalEventHandler;
 use esrs::store::postgres::PgStoreError;
 use esrs::store::StoreEvent;
 
-use crate::common::{BasicAggregate, BasicEvent, BasicView};
+use crate::common::basic::view::BasicView;
+use crate::common::basic::{BasicAggregate, BasicEvent};
 
 /// The `BasicTransactionalEventHandlerV1` and `BasicTransactionalEventHandlerV1` exists in this
 /// example just for the sake of showing how a single transactional event handler, in this case called

--- a/examples/saga/main.rs
+++ b/examples/saga/main.rs
@@ -17,7 +17,8 @@ use esrs::store::EventStore;
 use esrs::AggregateState;
 
 use crate::aggregate::{SagaAggregate, SagaCommand, SagaEvent};
-use crate::common::{new_pool, CommonError};
+use crate::common::util::new_pool;
+use crate::common::CommonError;
 use crate::event_handler::SagaEventHandler;
 
 mod aggregate;

--- a/examples/shared_view/main.rs
+++ b/examples/shared_view/main.rs
@@ -7,9 +7,12 @@ use esrs::manager::AggregateManager;
 use esrs::store::postgres::{PgStore, PgStoreBuilder, PgStoreError};
 use esrs::AggregateState;
 
-use crate::common::{
-    new_pool, AggregateA, AggregateB, CommandA, CommandB, CommonError, SharedEventHandler, SharedView,
-};
+use crate::common::a::{AggregateA, CommandA};
+use crate::common::b::{AggregateB, CommandB};
+use crate::common::shared::event_handler::SharedEventHandler;
+use crate::common::shared::view::SharedView;
+use crate::common::util::new_pool;
+use crate::common::CommonError;
 
 #[path = "../common/lib.rs"]
 mod common;

--- a/examples/store_crud/main.rs
+++ b/examples/store_crud/main.rs
@@ -40,7 +40,8 @@ use esrs::store::postgres::{PgStore, PgStoreBuilder};
 use esrs::store::{EventStore, StoreEvent};
 use esrs::AggregateState;
 
-use crate::common::{new_pool, BasicAggregate, BasicEvent};
+use crate::common::basic::{BasicAggregate, BasicEvent};
+use crate::common::util::new_pool;
 
 #[path = "../common/lib.rs"]
 mod common;

--- a/examples/transactional_view/main.rs
+++ b/examples/transactional_view/main.rs
@@ -22,7 +22,9 @@ use esrs::store::postgres::{PgStore, PgStoreBuilder, PgStoreError};
 use esrs::store::EventStore;
 use esrs::AggregateState;
 
-use crate::common::{new_pool, BasicAggregate, BasicCommand, BasicError, BasicView, BasicViewRow};
+use crate::common::basic::view::{BasicView, BasicViewRow};
+use crate::common::basic::{BasicAggregate, BasicCommand, BasicError};
+use crate::common::util::new_pool;
 use crate::transactional_event_handler::BasicTransactionalEventHandler;
 
 #[path = "../common/lib.rs"]

--- a/examples/transactional_view/transactional_event_handler.rs
+++ b/examples/transactional_view/transactional_event_handler.rs
@@ -5,7 +5,8 @@ use esrs::handler::TransactionalEventHandler;
 use esrs::store::postgres::PgStoreError;
 use esrs::store::StoreEvent;
 
-use crate::common::{BasicAggregate, BasicEvent, BasicView};
+use crate::common::basic::view::BasicView;
+use crate::common::basic::{BasicAggregate, BasicEvent};
 
 pub struct BasicTransactionalEventHandler {
     pub view: BasicView,

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -69,7 +69,7 @@ pub trait EventStore {
 }
 
 /// Blanket implementation making an [`EventStore`] every (smart) pointer to an [`EventStore`],
-/// e.g. &Store, Box<Store>, Arc<Store>.
+/// e.g. `&Store`, `Box<Store>`, `Arc<Store>`.
 /// This is particularly useful when there's the need in your codebase to have a generic [`EventStore`].
 #[async_trait]
 impl<A, E, T, S> EventStore for T

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -68,17 +68,18 @@ pub trait EventStore {
     async fn delete(&self, aggregate_id: Uuid) -> Result<(), Self::Error>;
 }
 
-/// Default generic implementation for every type implementing [`Deref`] where its `Target` is a
-/// `dyn` [`EventStore`]. This is particularly useful when there's the need in your codebase to have
-/// a generic [`EventStore`].
+/// Blanket implementation making an [`EventStore`] every (smart) pointer to an [`EventStore`],
+/// e.g. &Store, Box<Store>, Arc<Store>.
+/// This is particularly useful when there's the need in your codebase to have a generic [`EventStore`].
 #[async_trait]
-impl<A, E, T> EventStore for T
+impl<A, E, T, S> EventStore for T
 where
     A: crate::Aggregate,
     A::Event: Send + Sync,
     A::State: Send,
     E: std::error::Error,
-    T: Deref<Target = dyn EventStore<Aggregate = A, Error = E> + Sync> + Sync,
+    S: EventStore<Aggregate = A, Error = E> + ?Sized,
+    T: Deref<Target = S> + Sync,
     for<'a> A::Event: 'a,
 {
     type Aggregate = A;


### PR DESCRIPTION
The blanket implementation should be generic in the EventStore.
As it is currently written, it works for (smart) pointers to trait objects ONLY, and not for concrete types that implement the EventStore trait, e.g.
`Arc<dyn EventStore>` receives the target implementation, whereas `Arc<PgStore>` does not