### PR TITLE
Expose option for setting ID function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ tokio = { version = "1.6", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 # Uuid generation
-uuid = { version = "1.1", features = ["serde", "v4"] }
+uuid = { version = "1.6", features = ["serde", "v4", "v7"] }
 # Time esrs-core
 chrono = { version = "0.4", features = ["serde"] }
 # Build async trait

--- a/src/store/postgres/builder.rs
+++ b/src/store/postgres/builder.rs
@@ -17,8 +17,10 @@ use super::{PgStore, Schema};
 /// The `UuidFormat` enum defines the UUID format preference:
 ///
 /// - `V4`: Uses the random UUID version 4 as defined by RFC 9562 section 5.4.
+/// - `V7`: Uses the time-ordered UUID version 7 as defined by RFC 9562 section 5.7.
 pub enum UuidFormat {
     V4,
+    V7,
 }
 
 /// Struct used to build a brand new [`PgStore`].

--- a/src/store/postgres/builder.rs
+++ b/src/store/postgres/builder.rs
@@ -14,6 +14,13 @@ use crate::Aggregate;
 use super::persistable::Persistable;
 use super::{PgStore, Schema};
 
+/// The `UuidFormat` enum defines the UUID format preference:
+///
+/// - `V4`: Uses the random UUID version 4 as defined by RFC 9562 section 5.4.
+pub enum UuidFormat {
+    V4,
+}
+
 /// Struct used to build a brand new [`PgStore`].
 pub struct PgStoreBuilder<A, Schema = <A as Aggregate>::Event>
 where
@@ -137,6 +144,7 @@ where
                 event_handlers: RwLock::new(self.event_handlers),
                 transactional_event_handlers: self.transactional_event_handlers,
                 event_buses: self.event_buses,
+                event_id_format: UuidFormat::V4,
             }),
             _schema: self._schema,
         })

--- a/src/store/postgres/builder.rs
+++ b/src/store/postgres/builder.rs
@@ -31,6 +31,7 @@ where
     event_handlers: Vec<Box<dyn EventHandler<A> + Send>>,
     transactional_event_handlers: Vec<Box<dyn TransactionalEventHandler<A, PgStoreError, PgConnection> + Send>>,
     event_buses: Vec<Box<dyn EventBus<A> + Send>>,
+    event_id_format: UuidFormat,
     run_migrations: bool,
     _schema: PhantomData<Schema>,
 }
@@ -47,6 +48,7 @@ where
             event_handlers: vec![],
             transactional_event_handlers: vec![],
             event_buses: vec![],
+            event_id_format: UuidFormat::V4,
             run_migrations: true,
             _schema: PhantomData,
         }
@@ -119,8 +121,15 @@ where
             event_handlers: self.event_handlers,
             transactional_event_handlers: self.transactional_event_handlers,
             event_buses: self.event_buses,
+            event_id_format: self.event_id_format,
             _schema: PhantomData,
         }
+    }
+
+    /// Set the UUID format of event IDs.
+    pub fn with_event_id_format(mut self, event_id_format: UuidFormat) -> Self {
+        self.event_id_format = event_id_format;
+        self
     }
 
     /// This function runs all the needed [`Migrations`], atomically setting up the database if
@@ -144,7 +153,7 @@ where
                 event_handlers: RwLock::new(self.event_handlers),
                 transactional_event_handlers: self.transactional_event_handlers,
                 event_buses: self.event_buses,
-                event_id_format: UuidFormat::V4,
+                event_id_format: self.event_id_format,
             }),
             _schema: self._schema,
         })

--- a/src/store/postgres/event_store.rs
+++ b/src/store/postgres/event_store.rs
@@ -99,6 +99,7 @@ where
     ) -> Result<StoreEvent<A::Event>, PgStoreError> {
         let id: Uuid = match self.inner.event_id_format {
             UuidFormat::V4 => Uuid::new_v4(),
+            UuidFormat::V7 => Uuid::now_v7(),
         };
 
         #[cfg(feature = "upcasting")]


### PR DESCRIPTION
[`AggregateState::with_id`](https://docs.rs/esrs/latest/esrs/struct.AggregateState.html#method.with_id) allows setting a custom ID for an aggregate.

I wanted to use a different UUID version for event IDs but those are generated right before persisting an event without a way to override:

https://github.com/primait/event_sourcing.rs/blob/8766a1c9129c3ab7695195bff2f0e9b50117652c/src/store/postgres/event_store.rs#L98

Specifically, I would prefer to use [UUID version 7](https://www.rfc-editor.org/rfc/rfc9562.html#name-uuid-version-7). Considering events are inserted chronologically, [using a sequential version could improve performance](https://www.2ndquadrant.com/en/blog/sequential-uuid-generators/). Anyway, this is about the capability and not whether any version is better.

I'm new to Rust so please let me know if there's a better way to enable this or if, say, a rename will make it more idiomatic.