### PR TITLE
Allow a single aggregate to be rebuilt

### DIFF
--- a/src/rebuilder/mod.rs
+++ b/src/rebuilder/mod.rs
@@ -2,6 +2,7 @@ use async_trait::async_trait;
 
 #[cfg(feature = "postgres")]
 pub use pg_rebuilder::PgRebuilder;
+use uuid::Uuid;
 
 use crate::Aggregate;
 
@@ -17,5 +18,6 @@ where
     type Error: std::error::Error;
 
     async fn by_aggregate_id(&self, executor: Self::Executor) -> Result<(), Self::Error>;
+    async fn just_one_aggregate(&self, aggregate_id: Uuid, executor: Self::Executor) -> Result<(), Self::Error>;
     async fn all_at_once(&self, executor: Self::Executor) -> Result<(), Self::Error>;
 }


### PR DESCRIPTION
Hi, sometime we need to rebuild handlers for a single aggregate but rebuilder didn't permit it. I've added some code to allow it.