### PR TITLE
chore: upgrade lapin to v3.7.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ sqlx = { version = "0.8.0", features = ["runtime-tokio-native-tls", "uuid", "jso
 # Kafka library
 rdkafka = { version = "0.35.*", features = ["ssl-vendored"], optional = true }
 # Rabbit library
-lapin = { version = "2.1.1", optional = true }
+lapin = { version = "3.7.2", optional = true }
 # Builder pattern
 typed-builder = { version = "0.20.0", optional = true }
 bb8 = "0.8.1"

--- a/src/bus/rabbit/mod.rs
+++ b/src/bus/rabbit/mod.rs
@@ -35,7 +35,7 @@ impl ManageConnection for RabbitConnectionManager {
 
     async fn is_valid(&self, conn: &mut Self::Connection) -> Result<(), Self::Error> {
         if self.has_broken(conn) {
-            return Err(lapin::Error::InvalidConnectionState(conn.status().state()));
+            return Err(lapin::ErrorKind::InvalidConnectionState(conn.status().state()).into());
         }
         Ok(())
     }
@@ -63,7 +63,13 @@ impl ManageConnection for RabbitChannelManager {
             Ok(connection) => connection,
             Err(e) => match e {
                 bb8::RunError::User(e) => return Err(e),
-                bb8::RunError::TimedOut => return Err(lapin::Error::InvalidChannelState(lapin::ChannelState::Closed)),
+                bb8::RunError::TimedOut => {
+                    return Err(lapin::ErrorKind::InvalidChannelState(
+                        lapin::ChannelState::Closed,
+                        "connection timed out",
+                    )
+                    .into())
+                }
             },
         };
         let channel = connection.create_channel().await?;
@@ -80,7 +86,7 @@ impl ManageConnection for RabbitChannelManager {
 
     async fn is_valid(&self, conn: &mut Self::Connection) -> Result<(), Self::Error> {
         if self.has_broken(conn) {
-            return Err(lapin::Error::InvalidChannelState(conn.status().state()));
+            return Err(lapin::ErrorKind::InvalidChannelState(conn.status().state(), "channel is closed").into());
         }
         Ok(())
     }


### PR DESCRIPTION
https://github.com/primait/event_sourcing.rs/pull/226 contains a lapin bump from `2.1.1` directly to `4.7.4`. It seems more sensible to at least run a few tests with v3 before jumping directly to 4