### PR TITLE
[feat] Wrap aggregate state around a view with aggregate context data

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ pub enum BookError {
 And now let's put all together in the `Aggregate`, implementing `handle_command` and `apply_events` functions too.
 
 ```rust
-...
+// ...
 
 impl Aggregate for Book {
     const NAME: &'static str = "book";
@@ -172,7 +172,7 @@ impl Aggregate for Book {
         }
     }
 
-    fn apply_event(state: Self::State, payload: Self::Event) -> Self::State {
+    fn apply_event(state: Self::State, payload: Self::Event, _ctx: AggregateContext) -> Self::State {
         match payload {
             BookEvent::Bought { num_of_copies } => BookState { leftover: state.leftover - num_of_copies },
             BookEvent::Returned { num_of_copies } => BookState { leftover: state.leftover + num_of_copies },

--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ And now let's put all together in the `Aggregate`, implementing `handle_command`
 
 ```rust
 // ...
+use esrs::{Aggregate, AggregateView};
 
 impl Aggregate for Book {
     const NAME: &'static str = "book";
@@ -164,7 +165,7 @@ impl Aggregate for Book {
     type Event = BookEvent;
     type Error = BookError;
 
-    fn handle_command(state: &Self::State, command: Self::Command) -> Result<Vec<Self::Event>, Self::Error> {
+    fn handle_command(state: AggregateView<&Self::State>, command: Self::Command) -> Result<Vec<Self::Event>, Self::Error> {
         match command {
             BookCommand::Buy { num_of_copies } if state.leftover < num_of_copies => Err(BookError::NotEnoughCopies),
             BookCommand::Buy { num_of_copies } => Ok(vec![BookEvent::Bought { num_of_copies }]),
@@ -172,7 +173,7 @@ impl Aggregate for Book {
         }
     }
 
-    fn apply_event(state: Self::State, payload: Self::Event, _ctx: AggregateContext) -> Self::State {
+    fn apply_event(state: AggregateView<Self::State>, payload: Self::Event) -> Self::State {
         match payload {
             BookEvent::Bought { num_of_copies } => BookState { leftover: state.leftover - num_of_copies },
             BookEvent::Returned { num_of_copies } => BookState { leftover: state.leftover + num_of_copies },

--- a/examples/common/a.rs
+++ b/examples/common/a.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use esrs::Aggregate;
+use esrs::{Aggregate, AggregateContext};
 
 use crate::common::CommonError;
 
@@ -21,7 +21,7 @@ impl Aggregate for AggregateA {
         }])
     }
 
-    fn apply_event(state: Self::State, payload: Self::Event) -> Self::State {
+    fn apply_event(state: Self::State, payload: Self::Event, _ctx: AggregateContext) -> Self::State {
         state + payload.v
     }
 }

--- a/examples/common/a.rs
+++ b/examples/common/a.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use esrs::{Aggregate, AggregateContext};
+use esrs::{Aggregate, AggregateView};
 
 use crate::common::CommonError;
 
@@ -14,15 +14,18 @@ impl Aggregate for AggregateA {
     type Event = EventA;
     type Error = CommonError;
 
-    fn handle_command(_state: &Self::State, command: Self::Command) -> Result<Vec<Self::Event>, Self::Error> {
+    fn handle_command(
+        _state: AggregateView<&Self::State>,
+        command: Self::Command,
+    ) -> Result<Vec<Self::Event>, Self::Error> {
         Ok(vec![EventA {
             shared_id: command.shared_id,
             v: command.v,
         }])
     }
 
-    fn apply_event(state: Self::State, payload: Self::Event, _ctx: AggregateContext) -> Self::State {
-        state + payload.v
+    fn apply_event(state: AggregateView<Self::State>, payload: Self::Event) -> Self::State {
+        *state + payload.v
     }
 }
 

--- a/examples/common/b.rs
+++ b/examples/common/b.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use esrs::{Aggregate, AggregateContext};
+use esrs::{Aggregate, AggregateView};
 
 use crate::common::CommonError;
 
@@ -14,15 +14,18 @@ impl Aggregate for AggregateB {
     type Event = EventB;
     type Error = CommonError;
 
-    fn handle_command(_state: &Self::State, command: Self::Command) -> Result<Vec<Self::Event>, Self::Error> {
+    fn handle_command(
+        _state: AggregateView<&Self::State>,
+        command: Self::Command,
+    ) -> Result<Vec<Self::Event>, Self::Error> {
         Ok(vec![EventB {
             shared_id: command.shared_id,
             v: command.v,
         }])
     }
 
-    fn apply_event(state: Self::State, payload: Self::Event, _ctx: AggregateContext) -> Self::State {
-        state + payload.v
+    fn apply_event(state: AggregateView<Self::State>, payload: Self::Event) -> Self::State {
+        *state + payload.v
     }
 }
 

--- a/examples/common/b.rs
+++ b/examples/common/b.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use esrs::Aggregate;
+use esrs::{Aggregate, AggregateContext};
 
 use crate::common::CommonError;
 
@@ -21,7 +21,7 @@ impl Aggregate for AggregateB {
         }])
     }
 
-    fn apply_event(state: Self::State, payload: Self::Event) -> Self::State {
+    fn apply_event(state: Self::State, payload: Self::Event, _ctx: AggregateContext) -> Self::State {
         state + payload.v
     }
 }

--- a/examples/common/basic/event_handler.rs
+++ b/examples/common/basic/event_handler.rs
@@ -8,7 +8,6 @@ use esrs::store::StoreEvent;
 use crate::common::basic::view::BasicView;
 use crate::common::basic::{BasicAggregate, BasicEvent};
 
-#[allow(dead_code)]
 #[derive(Clone)]
 pub struct BasicEventHandler {
     pub pool: Pool<Postgres>,

--- a/examples/common/basic/event_handler.rs
+++ b/examples/common/basic/event_handler.rs
@@ -8,6 +8,7 @@ use esrs::store::StoreEvent;
 use crate::common::basic::view::BasicView;
 use crate::common::basic::{BasicAggregate, BasicEvent};
 
+#[allow(dead_code)]
 #[derive(Clone)]
 pub struct BasicEventHandler {
     pub pool: Pool<Postgres>,

--- a/examples/common/basic/mod.rs
+++ b/examples/common/basic/mod.rs
@@ -5,7 +5,6 @@ use esrs::{Aggregate, AggregateView};
 pub mod event_handler;
 pub mod view;
 
-#[allow(dead_code)]
 #[derive(Clone)]
 pub struct BasicAggregate;
 
@@ -32,12 +31,10 @@ impl Aggregate for BasicAggregate {
     fn apply_event(_state: AggregateView<Self::State>, _payload: Self::Event) -> Self::State {}
 }
 
-#[allow(dead_code)]
 pub struct BasicCommand {
     pub content: String,
 }
 
-#[allow(dead_code)]
 #[derive(Serialize, Deserialize, PartialEq, Clone)]
 pub struct BasicEvent {
     pub content: String,

--- a/examples/common/basic/mod.rs
+++ b/examples/common/basic/mod.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use esrs::{Aggregate, AggregateContext};
+use esrs::{Aggregate, AggregateView};
 
 pub mod event_handler;
 pub mod view;
@@ -16,7 +16,10 @@ impl Aggregate for BasicAggregate {
     type Event = BasicEvent;
     type Error = BasicError;
 
-    fn handle_command(_state: &Self::State, command: Self::Command) -> Result<Vec<Self::Event>, Self::Error> {
+    fn handle_command(
+        _state: AggregateView<&Self::State>,
+        command: Self::Command,
+    ) -> Result<Vec<Self::Event>, Self::Error> {
         if command.content.is_empty() {
             Err(BasicError::EmptyContent)
         } else {
@@ -26,7 +29,7 @@ impl Aggregate for BasicAggregate {
         }
     }
 
-    fn apply_event(_state: Self::State, _payload: Self::Event, _ctx: AggregateContext) -> Self::State {}
+    fn apply_event(_state: AggregateView<Self::State>, _payload: Self::Event) -> Self::State {}
 }
 
 #[allow(dead_code)]

--- a/examples/common/basic/mod.rs
+++ b/examples/common/basic/mod.rs
@@ -1,10 +1,11 @@
 use serde::{Deserialize, Serialize};
 
-use esrs::Aggregate;
+use esrs::{Aggregate, AggregateContext};
 
 pub mod event_handler;
 pub mod view;
 
+#[allow(dead_code)]
 #[derive(Clone)]
 pub struct BasicAggregate;
 
@@ -25,13 +26,15 @@ impl Aggregate for BasicAggregate {
         }
     }
 
-    fn apply_event(_state: Self::State, _payload: Self::Event) -> Self::State {}
+    fn apply_event(_state: Self::State, _payload: Self::Event, _ctx: AggregateContext) -> Self::State {}
 }
 
+#[allow(dead_code)]
 pub struct BasicCommand {
     pub content: String,
 }
 
+#[allow(dead_code)]
 #[derive(Serialize, Deserialize, PartialEq, Clone)]
 pub struct BasicEvent {
     pub content: String,

--- a/examples/readme/main.rs
+++ b/examples/readme/main.rs
@@ -7,7 +7,7 @@ use esrs::handler::{EventHandler, TransactionalEventHandler};
 use esrs::manager::AggregateManager;
 use esrs::store::postgres::{PgStore, PgStoreBuilder, PgStoreError};
 use esrs::store::StoreEvent;
-use esrs::Aggregate;
+use esrs::{Aggregate, AggregateContext};
 
 use crate::common::util::new_pool;
 
@@ -55,7 +55,7 @@ impl Aggregate for Book {
         }
     }
 
-    fn apply_event(state: Self::State, payload: Self::Event) -> Self::State {
+    fn apply_event(state: Self::State, payload: Self::Event, _ctx: AggregateContext) -> Self::State {
         match payload {
             BookEvent::Bought { num_of_copies } => BookState {
                 leftover: state.leftover - num_of_copies,

--- a/examples/readme/main.rs
+++ b/examples/readme/main.rs
@@ -7,7 +7,7 @@ use esrs::handler::{EventHandler, TransactionalEventHandler};
 use esrs::manager::AggregateManager;
 use esrs::store::postgres::{PgStore, PgStoreBuilder, PgStoreError};
 use esrs::store::StoreEvent;
-use esrs::{Aggregate, AggregateContext};
+use esrs::{Aggregate, AggregateView};
 
 use crate::common::util::new_pool;
 
@@ -47,7 +47,10 @@ impl Aggregate for Book {
     type Event = BookEvent;
     type Error = BookError;
 
-    fn handle_command(state: &Self::State, command: Self::Command) -> Result<Vec<Self::Event>, Self::Error> {
+    fn handle_command(
+        state: AggregateView<&Self::State>,
+        command: Self::Command,
+    ) -> Result<Vec<Self::Event>, Self::Error> {
         match command {
             BookCommand::Buy { num_of_copies } if state.leftover < num_of_copies => Err(BookError::NotEnoughCopies),
             BookCommand::Buy { num_of_copies } => Ok(vec![BookEvent::Bought { num_of_copies }]),
@@ -55,7 +58,7 @@ impl Aggregate for Book {
         }
     }
 
-    fn apply_event(state: Self::State, payload: Self::Event, _ctx: AggregateContext) -> Self::State {
+    fn apply_event(state: AggregateView<Self::State>, payload: Self::Event) -> Self::State {
         match payload {
             BookEvent::Bought { num_of_copies } => BookState {
                 leftover: state.leftover - num_of_copies,

--- a/examples/saga/aggregate.rs
+++ b/examples/saga/aggregate.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use esrs::{Aggregate, AggregateContext};
+use esrs::{Aggregate, AggregateView};
 
 use crate::common::CommonError;
 
@@ -14,14 +14,17 @@ impl Aggregate for SagaAggregate {
     type Event = SagaEvent;
     type Error = CommonError;
 
-    fn handle_command(_state: &Self::State, command: Self::Command) -> Result<Vec<Self::Event>, Self::Error> {
+    fn handle_command(
+        _state: AggregateView<&Self::State>,
+        command: Self::Command,
+    ) -> Result<Vec<Self::Event>, Self::Error> {
         match command {
             SagaCommand::RequestMutation => Ok(vec![SagaEvent::MutationRequested]),
             SagaCommand::RegisterMutation => Ok(vec![SagaEvent::MutationRegistered]),
         }
     }
 
-    fn apply_event(_state: Self::State, _payload: Self::Event, _ctx: AggregateContext) -> Self::State {}
+    fn apply_event(_state: AggregateView<Self::State>, _payload: Self::Event) -> Self::State {}
 }
 
 pub enum SagaCommand {

--- a/examples/saga/aggregate.rs
+++ b/examples/saga/aggregate.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use esrs::Aggregate;
+use esrs::{Aggregate, AggregateContext};
 
 use crate::common::CommonError;
 
@@ -21,7 +21,7 @@ impl Aggregate for SagaAggregate {
         }
     }
 
-    fn apply_event(_state: Self::State, _payload: Self::Event) -> Self::State {}
+    fn apply_event(_state: Self::State, _payload: Self::Event, _ctx: AggregateContext) -> Self::State {}
 }
 
 pub enum SagaCommand {

--- a/examples/schema/adding_schema.rs
+++ b/examples/schema/adding_schema.rs
@@ -29,6 +29,8 @@ pub(crate) enum Command {}
 mod before_schema {
     //! This module represents the code of the initial iteration of the system before the
     //! introduction of the schema.
+    use esrs::AggregateContext;
+
     use super::*;
     pub(crate) struct Aggregate;
 
@@ -43,7 +45,7 @@ mod before_schema {
             match command {}
         }
 
-        fn apply_event(state: Self::State, payload: Self::Event) -> Self::State {
+        fn apply_event(state: Self::State, payload: Self::Event, _ctx: AggregateContext) -> Self::State {
             let mut events = state.events;
             events.push(payload);
 
@@ -71,6 +73,8 @@ mod before_schema {
 
 mod after_schema {
     //! This module represents the code after the introduction of the schema.
+    use esrs::AggregateContext;
+
     use super::*;
     pub(crate) struct Aggregate;
 
@@ -85,7 +89,7 @@ mod after_schema {
             match command {}
         }
 
-        fn apply_event(state: Self::State, payload: Self::Event) -> Self::State {
+        fn apply_event(state: Self::State, payload: Self::Event, _ctx: AggregateContext) -> Self::State {
             let mut events = state.events;
             events.push(payload);
 

--- a/examples/schema/adding_schema.rs
+++ b/examples/schema/adding_schema.rs
@@ -29,7 +29,8 @@ pub(crate) enum Command {}
 mod before_schema {
     //! This module represents the code of the initial iteration of the system before the
     //! introduction of the schema.
-    use esrs::AggregateContext;
+
+    use esrs::AggregateView;
 
     use super::*;
     pub(crate) struct Aggregate;
@@ -41,12 +42,15 @@ mod before_schema {
         type Event = Event;
         type Error = CommonError;
 
-        fn handle_command(_state: &Self::State, command: Self::Command) -> Result<Vec<Self::Event>, Self::Error> {
+        fn handle_command(
+            _state: AggregateView<&Self::State>,
+            command: Self::Command,
+        ) -> Result<Vec<Self::Event>, Self::Error> {
             match command {}
         }
 
-        fn apply_event(state: Self::State, payload: Self::Event, _ctx: AggregateContext) -> Self::State {
-            let mut events = state.events;
+        fn apply_event(state: AggregateView<Self::State>, payload: Self::Event) -> Self::State {
+            let mut events = state.into_inner().events;
             events.push(payload);
 
             Self::State { events }
@@ -73,7 +77,8 @@ mod before_schema {
 
 mod after_schema {
     //! This module represents the code after the introduction of the schema.
-    use esrs::AggregateContext;
+
+    use esrs::AggregateView;
 
     use super::*;
     pub(crate) struct Aggregate;
@@ -85,12 +90,15 @@ mod after_schema {
         type Event = Event;
         type Error = CommonError;
 
-        fn handle_command(_state: &Self::State, command: Self::Command) -> Result<Vec<Self::Event>, Self::Error> {
+        fn handle_command(
+            _state: AggregateView<&Self::State>,
+            command: Self::Command,
+        ) -> Result<Vec<Self::Event>, Self::Error> {
             match command {}
         }
 
-        fn apply_event(state: Self::State, payload: Self::Event, _ctx: AggregateContext) -> Self::State {
-            let mut events = state.events;
+        fn apply_event(state: AggregateView<Self::State>, payload: Self::Event) -> Self::State {
+            let mut events = state.into_inner().events;
             events.push(payload);
 
             Self::State { events }

--- a/examples/schema/deprecating_events.rs
+++ b/examples/schema/deprecating_events.rs
@@ -27,6 +27,8 @@ pub(crate) enum Command {}
 
 mod before_deprecation {
     //! This module represents the code of the initial iteration of the system.
+    use esrs::AggregateContext;
+
     use super::*;
     pub(crate) struct Aggregate;
     impl esrs::Aggregate for Aggregate {
@@ -40,7 +42,7 @@ mod before_deprecation {
             match command {}
         }
 
-        fn apply_event(state: Self::State, payload: Self::Event) -> Self::State {
+        fn apply_event(state: Self::State, payload: Self::Event, _ctx: AggregateContext) -> Self::State {
             let mut events = state.events;
             events.push(payload);
 
@@ -91,6 +93,8 @@ mod before_deprecation {
 mod after_deprecation {
     //! This module represents the code after `Event::B` has been deprecated and a new event
     //! (`Event::C`) has been introduced
+    use esrs::AggregateContext;
+
     use super::*;
 
     pub(crate) struct Aggregate;
@@ -105,7 +109,7 @@ mod after_deprecation {
             match command {}
         }
 
-        fn apply_event(state: Self::State, payload: Self::Event) -> Self::State {
+        fn apply_event(state: Self::State, payload: Self::Event, _ctx: AggregateContext) -> Self::State {
             let mut events = state.events;
             events.push(payload);
 

--- a/examples/schema/deprecating_events.rs
+++ b/examples/schema/deprecating_events.rs
@@ -27,7 +27,8 @@ pub(crate) enum Command {}
 
 mod before_deprecation {
     //! This module represents the code of the initial iteration of the system.
-    use esrs::AggregateContext;
+
+    use esrs::AggregateView;
 
     use super::*;
     pub(crate) struct Aggregate;
@@ -38,12 +39,15 @@ mod before_deprecation {
         type Event = Event;
         type Error = CommonError;
 
-        fn handle_command(_state: &Self::State, command: Self::Command) -> Result<Vec<Self::Event>, Self::Error> {
+        fn handle_command(
+            _state: AggregateView<&Self::State>,
+            command: Self::Command,
+        ) -> Result<Vec<Self::Event>, Self::Error> {
             match command {}
         }
 
-        fn apply_event(state: Self::State, payload: Self::Event, _ctx: AggregateContext) -> Self::State {
-            let mut events = state.events;
+        fn apply_event(state: AggregateView<Self::State>, payload: Self::Event) -> Self::State {
+            let mut events = state.into_inner().events;
             events.push(payload);
 
             Self::State { events }
@@ -93,7 +97,8 @@ mod before_deprecation {
 mod after_deprecation {
     //! This module represents the code after `Event::B` has been deprecated and a new event
     //! (`Event::C`) has been introduced
-    use esrs::AggregateContext;
+
+    use esrs::AggregateView;
 
     use super::*;
 
@@ -105,12 +110,15 @@ mod after_deprecation {
         type Event = Event;
         type Error = CommonError;
 
-        fn handle_command(_state: &Self::State, command: Self::Command) -> Result<Vec<Self::Event>, Self::Error> {
+        fn handle_command(
+            _state: AggregateView<&Self::State>,
+            command: Self::Command,
+        ) -> Result<Vec<Self::Event>, Self::Error> {
             match command {}
         }
 
-        fn apply_event(state: Self::State, payload: Self::Event, _ctx: AggregateContext) -> Self::State {
-            let mut events = state.events;
+        fn apply_event(state: AggregateView<Self::State>, payload: Self::Event) -> Self::State {
+            let mut events = state.into_inner().events;
             events.push(payload);
 
             Self::State { events }

--- a/examples/schema/upcasting.rs
+++ b/examples/schema/upcasting.rs
@@ -28,7 +28,8 @@ pub(crate) enum Command {}
 
 mod before_upcasting {
     //! This module represents the code of the initial iteration of the system.
-    use esrs::AggregateContext;
+
+    use esrs::AggregateView;
 
     use super::*;
     pub(crate) struct Aggregate;
@@ -39,12 +40,15 @@ mod before_upcasting {
         type Event = Event;
         type Error = CommonError;
 
-        fn handle_command(_state: &Self::State, command: Self::Command) -> Result<Vec<Self::Event>, Self::Error> {
+        fn handle_command(
+            _state: AggregateView<&Self::State>,
+            command: Self::Command,
+        ) -> Result<Vec<Self::Event>, Self::Error> {
             match command {}
         }
 
-        fn apply_event(state: Self::State, payload: Self::Event, _ctx: AggregateContext) -> Self::State {
-            let mut events = state.events;
+        fn apply_event(state: AggregateView<Self::State>, payload: Self::Event) -> Self::State {
+            let mut events = state.into_inner().events;
             events.push(payload);
 
             Self::State { events }
@@ -93,7 +97,8 @@ mod before_upcasting {
 
 mod after_upcasting {
     //! This module represents the code after the upcasting has been implemented
-    use esrs::AggregateContext;
+
+    use esrs::AggregateView;
 
     use super::*;
     pub(crate) struct Aggregate;
@@ -104,12 +109,15 @@ mod after_upcasting {
         type Event = Event;
         type Error = CommonError;
 
-        fn handle_command(_state: &Self::State, command: Self::Command) -> Result<Vec<Self::Event>, Self::Error> {
+        fn handle_command(
+            _state: AggregateView<&Self::State>,
+            command: Self::Command,
+        ) -> Result<Vec<Self::Event>, Self::Error> {
             match command {}
         }
 
-        fn apply_event(state: Self::State, payload: Self::Event, _ctx: AggregateContext) -> Self::State {
-            let mut events = state.events;
+        fn apply_event(state: AggregateView<Self::State>, payload: Self::Event) -> Self::State {
+            let mut events = state.into_inner().events;
             events.push(payload);
 
             Self::State { events }

--- a/examples/schema/upcasting.rs
+++ b/examples/schema/upcasting.rs
@@ -28,6 +28,8 @@ pub(crate) enum Command {}
 
 mod before_upcasting {
     //! This module represents the code of the initial iteration of the system.
+    use esrs::AggregateContext;
+
     use super::*;
     pub(crate) struct Aggregate;
     impl esrs::Aggregate for Aggregate {
@@ -41,7 +43,7 @@ mod before_upcasting {
             match command {}
         }
 
-        fn apply_event(state: Self::State, payload: Self::Event) -> Self::State {
+        fn apply_event(state: Self::State, payload: Self::Event, _ctx: AggregateContext) -> Self::State {
             let mut events = state.events;
             events.push(payload);
 
@@ -91,6 +93,8 @@ mod before_upcasting {
 
 mod after_upcasting {
     //! This module represents the code after the upcasting has been implemented
+    use esrs::AggregateContext;
+
     use super::*;
     pub(crate) struct Aggregate;
     impl esrs::Aggregate for Aggregate {
@@ -104,7 +108,7 @@ mod after_upcasting {
             match command {}
         }
 
-        fn apply_event(state: Self::State, payload: Self::Event) -> Self::State {
+        fn apply_event(state: Self::State, payload: Self::Event, _ctx: AggregateContext) -> Self::State {
             let mut events = state.events;
             events.push(payload);
 

--- a/examples/upcasting/a.rs
+++ b/examples/upcasting/a.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use esrs::Aggregate;
-use esrs::{event::Upcaster, AggregateContext};
+use esrs::{event::Upcaster, AggregateView};
 
 use crate::{Command, Error};
 
@@ -83,14 +83,17 @@ impl Aggregate for AggregateA {
     type Event = Event;
     type Error = Error;
 
-    fn handle_command(_state: &Self::State, command: Self::Command) -> Result<Vec<Self::Event>, Self::Error> {
+    fn handle_command(
+        _state: AggregateView<&Self::State>,
+        command: Self::Command,
+    ) -> Result<Vec<Self::Event>, Self::Error> {
         match command {
             Self::Command::Increment { u } => Ok(vec![Self::Event::Incremented(IncPayload { u })]),
             Self::Command::Decrement { u } => Ok(vec![Self::Event::Decremented(DecPayload { u })]),
         }
     }
 
-    fn apply_event(state: Self::State, _: Self::Event, _ctx: AggregateContext) -> Self::State {
-        state
+    fn apply_event(state: AggregateView<Self::State>, _: Self::Event) -> Self::State {
+        state.into_inner()
     }
 }

--- a/examples/upcasting/a.rs
+++ b/examples/upcasting/a.rs
@@ -1,8 +1,8 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use esrs::event::Upcaster;
 use esrs::Aggregate;
+use esrs::{event::Upcaster, AggregateContext};
 
 use crate::{Command, Error};
 
@@ -90,7 +90,7 @@ impl Aggregate for AggregateA {
         }
     }
 
-    fn apply_event(state: Self::State, _: Self::Event) -> Self::State {
+    fn apply_event(state: Self::State, _: Self::Event, _ctx: AggregateContext) -> Self::State {
         state
     }
 }

--- a/examples/upcasting/b.rs
+++ b/examples/upcasting/b.rs
@@ -3,8 +3,8 @@ use std::convert::{TryFrom, TryInto};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use esrs::event::Upcaster;
 use esrs::Aggregate;
+use esrs::{event::Upcaster, AggregateContext};
 
 use crate::{Command, Error};
 
@@ -101,7 +101,7 @@ impl Aggregate for AggregateB {
         }
     }
 
-    fn apply_event(state: Self::State, _: Self::Event) -> Self::State {
+    fn apply_event(state: Self::State, _: Self::Event, _ctx: AggregateContext) -> Self::State {
         state
     }
 }

--- a/examples/upcasting/b.rs
+++ b/examples/upcasting/b.rs
@@ -3,8 +3,8 @@ use std::convert::{TryFrom, TryInto};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use esrs::Aggregate;
-use esrs::{event::Upcaster, AggregateContext};
+use esrs::event::Upcaster;
+use esrs::{Aggregate, AggregateView};
 
 use crate::{Command, Error};
 
@@ -94,14 +94,17 @@ impl Aggregate for AggregateB {
     type Event = Event;
     type Error = Error;
 
-    fn handle_command(_state: &Self::State, command: Self::Command) -> Result<Vec<Self::Event>, Self::Error> {
+    fn handle_command(
+        _state: AggregateView<&Self::State>,
+        command: Self::Command,
+    ) -> Result<Vec<Self::Event>, Self::Error> {
         match command {
             Self::Command::Increment { u } => Ok(vec![Self::Event::Incremented(IncPayload { u })]),
             Self::Command::Decrement { u } => Ok(vec![Self::Event::Decremented(DecPayload { u })]),
         }
     }
 
-    fn apply_event(state: Self::State, _: Self::Event, _ctx: AggregateContext) -> Self::State {
-        state
+    fn apply_event(state: AggregateView<Self::State>, _: Self::Event) -> Self::State {
+        state.into_inner()
     }
 }

--- a/src/aggregate.rs
+++ b/src/aggregate.rs
@@ -1,3 +1,19 @@
+use uuid::Uuid;
+
+/// Provides context about the current aggregate.
+/// This context applies no matter the backend used by the event store.
+pub struct AggregateContext {
+    /// The unique identifier used to identify the aggregate
+    pub aggregate_id: Uuid,
+}
+
+impl AggregateContext {
+    /// Construct the context with a single aggregate id
+    pub(crate) fn with_aggregate_id(id: Uuid) -> Self {
+        Self { aggregate_id: id }
+    }
+}
+
 /// The Aggregate trait is responsible for validating commands, mapping commands to events, and applying
 /// events onto the state.
 ///
@@ -44,5 +60,5 @@ pub trait Aggregate {
     /// to the state.
     ///
     /// If this is not the case, this function is allowed to panic.
-    fn apply_event(state: Self::State, payload: Self::Event) -> Self::State;
+    fn apply_event(state: Self::State, payload: Self::Event, ctx: AggregateContext) -> Self::State;
 }

--- a/src/aggregate.rs
+++ b/src/aggregate.rs
@@ -1,18 +1,4 @@
-use uuid::Uuid;
-
-/// Provides context about the current aggregate.
-/// This context applies no matter the backend used by the event store.
-pub struct AggregateContext {
-    /// The unique identifier used to identify the aggregate
-    pub aggregate_id: Uuid,
-}
-
-impl AggregateContext {
-    /// Construct the context with a single aggregate id
-    pub(crate) fn with_aggregate_id(id: Uuid) -> Self {
-        Self { aggregate_id: id }
-    }
-}
+use crate::AggregateView;
 
 /// The Aggregate trait is responsible for validating commands, mapping commands to events, and applying
 /// events onto the state.
@@ -54,11 +40,14 @@ pub trait Aggregate {
     ///
     /// Will return `Err` if the user of this library set up command validations. Every error here
     /// could be just a "domain error". No technical errors.
-    fn handle_command(state: &Self::State, command: Self::Command) -> Result<Vec<Self::Event>, Self::Error>;
+    fn handle_command(
+        state: AggregateView<&Self::State>,
+        command: Self::Command,
+    ) -> Result<Vec<Self::Event>, Self::Error>;
 
     /// Updates the aggregate state using the new event. This assumes that the event can be correctly applied
     /// to the state.
     ///
     /// If this is not the case, this function is allowed to panic.
-    fn apply_event(state: Self::State, payload: Self::Event, ctx: AggregateContext) -> Self::State;
+    fn apply_event(state: AggregateView<Self::State>, payload: Self::Event) -> Self::State;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,11 +11,12 @@
 //! performed over the event store table.
 
 pub use aggregate::Aggregate;
-pub use aggregate::AggregateContext;
 pub use state::AggregateState;
+pub use view::AggregateView;
 
 mod aggregate;
 mod state;
+mod view;
 
 pub mod bus;
 #[cfg(feature = "upcasting")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@
 //! performed over the event store table.
 
 pub use aggregate::Aggregate;
+pub use aggregate::AggregateContext;
 pub use state::AggregateState;
 
 mod aggregate;

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -5,7 +5,7 @@ pub use locked_load::LockedLoad;
 use uuid::Uuid;
 
 use crate::store::{EventStore, StoreEvent};
-use crate::{Aggregate, AggregateState};
+use crate::{Aggregate, AggregateState, AggregateView};
 
 /// The AggregateManager is responsible for coupling the Aggregate with a Store, so that the events
 /// can be persisted when handled, and the state can be reconstructed by loading and apply events sequentially.
@@ -44,7 +44,9 @@ where
         mut aggregate_state: AggregateState<<E::Aggregate as Aggregate>::State>,
         command: <E::Aggregate as Aggregate>::Command,
     ) -> Result<Result<<E::Aggregate as Aggregate>::State, <E::Aggregate as Aggregate>::Error>, E::Error> {
-        match <E::Aggregate as Aggregate>::handle_command(aggregate_state.inner(), command) {
+        let context = AggregateView::new(*aggregate_state.id(), aggregate_state.inner());
+
+        match <E::Aggregate as Aggregate>::handle_command(context, command) {
             Err(domain_error) => Ok(Err(domain_error)),
             Ok(events) => match self.event_store.persist(&mut aggregate_state, events).await {
                 Ok(store_events) => Ok(Ok(aggregate_state

--- a/src/manager.rs
+++ b/src/manager.rs
@@ -44,9 +44,9 @@ where
         mut aggregate_state: AggregateState<<E::Aggregate as Aggregate>::State>,
         command: <E::Aggregate as Aggregate>::Command,
     ) -> Result<Result<<E::Aggregate as Aggregate>::State, <E::Aggregate as Aggregate>::Error>, E::Error> {
-        let context = AggregateView::new(*aggregate_state.id(), aggregate_state.inner());
+        let view = AggregateView::new(*aggregate_state.id(), aggregate_state.inner());
 
-        match <E::Aggregate as Aggregate>::handle_command(context, command) {
+        match <E::Aggregate as Aggregate>::handle_command(view, command) {
             Err(domain_error) => Ok(Err(domain_error)),
             Ok(events) => match self.event_store.persist(&mut aggregate_state, events).await {
                 Ok(store_events) => Ok(Ok(aggregate_state

--- a/src/sql/migrations.rs
+++ b/src/sql/migrations.rs
@@ -45,7 +45,7 @@ mod tests {
     use sqlx::{Pool, Postgres};
 
     use crate::sql::migrations::{Migrations, MigrationsHandler};
-    use crate::Aggregate;
+    use crate::{Aggregate, AggregateContext};
 
     #[sqlx::test]
     async fn can_read_postgres_migrations(pool: Pool<Postgres>) {
@@ -76,6 +76,6 @@ mod tests {
             Ok(vec![])
         }
 
-        fn apply_event(_state: Self::State, _payload: Self::Event) -> Self::State {}
+        fn apply_event(_state: Self::State, _: Self::Event, _ctx: AggregateContext) -> Self::State {}
     }
 }

--- a/src/sql/migrations.rs
+++ b/src/sql/migrations.rs
@@ -45,7 +45,7 @@ mod tests {
     use sqlx::{Pool, Postgres};
 
     use crate::sql::migrations::{Migrations, MigrationsHandler};
-    use crate::{Aggregate, AggregateContext};
+    use crate::{Aggregate, AggregateView};
 
     #[sqlx::test]
     async fn can_read_postgres_migrations(pool: Pool<Postgres>) {
@@ -72,10 +72,13 @@ mod tests {
         type Event = TestEvent;
         type Error = Error;
 
-        fn handle_command(_state: &Self::State, _command: Self::Command) -> Result<Vec<Self::Event>, Self::Error> {
+        fn handle_command(
+            _state: AggregateView<&Self::State>,
+            _command: Self::Command,
+        ) -> Result<Vec<Self::Event>, Self::Error> {
             Ok(vec![])
         }
 
-        fn apply_event(_state: Self::State, _: Self::Event, _ctx: AggregateContext) -> Self::State {}
+        fn apply_event(_state: AggregateView<Self::State>, _: Self::Event) -> Self::State {}
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,9 +1,8 @@
-use uuid::Uuid;
-
-use crate::aggregate::AggregateContext;
 use crate::store::EventStoreLockGuard;
 use crate::store::StoreEvent;
 use crate::types::SequenceNumber;
+use crate::view::AggregateView;
+use uuid::Uuid;
 
 /// The internal state for an Aggregate.
 /// It contains:
@@ -67,17 +66,14 @@ impl<S: Default> AggregateState<S> {
     /// as dictated by `apply_event`.
     pub fn apply_store_events<T, F>(self, store_events: Vec<StoreEvent<T>>, apply_event: F) -> Self
     where
-        F: Fn(S, T, AggregateContext) -> S,
+        F: Fn(AggregateView<S>, T) -> S,
     {
         let aggregate_id = self.id;
 
         store_events.into_iter().fold(self, |state, store_event| {
+            let context = AggregateView::new(aggregate_id, state.inner);
             let sequence_number = *store_event.sequence_number();
-            let inner = apply_event(
-                state.inner,
-                store_event.payload,
-                AggregateContext::with_aggregate_id(aggregate_id),
-            );
+            let inner = apply_event(context, store_event.payload);
 
             Self {
                 sequence_number,

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,5 +1,6 @@
 use uuid::Uuid;
 
+use crate::aggregate::AggregateContext;
 use crate::store::EventStoreLockGuard;
 use crate::store::StoreEvent;
 use crate::types::SequenceNumber;
@@ -66,11 +67,17 @@ impl<S: Default> AggregateState<S> {
     /// as dictated by `apply_event`.
     pub fn apply_store_events<T, F>(self, store_events: Vec<StoreEvent<T>>, apply_event: F) -> Self
     where
-        F: Fn(S, T) -> S,
+        F: Fn(S, T, AggregateContext) -> S,
     {
+        let aggregate_id = self.id;
+
         store_events.into_iter().fold(self, |state, store_event| {
             let sequence_number = *store_event.sequence_number();
-            let inner = apply_event(state.inner, store_event.payload);
+            let inner = apply_event(
+                state.inner,
+                store_event.payload,
+                AggregateContext::with_aggregate_id(aggregate_id),
+            );
 
             Self {
                 sequence_number,

--- a/src/state.rs
+++ b/src/state.rs
@@ -71,9 +71,9 @@ impl<S: Default> AggregateState<S> {
         let aggregate_id = self.id;
 
         store_events.into_iter().fold(self, |state, store_event| {
-            let context = AggregateView::new(aggregate_id, state.inner);
+            let view = AggregateView::new(aggregate_id, state.inner);
             let sequence_number = *store_event.sequence_number();
-            let inner = apply_event(context, store_event.payload);
+            let inner = apply_event(view, store_event.payload);
 
             Self {
                 sequence_number,

--- a/src/view.rs
+++ b/src/view.rs
@@ -1,0 +1,80 @@
+//! An [`AggregateView`] wraps an aggregate state and provides access to
+//! information about the aggregate itself, such as its aggregate id.
+//!
+//! Aggregate views are primarily used by aggregate implementations when
+//! handling commands and applying events. They allow business logic to
+//! access aggregate metadata transparently.
+//!
+//! The wrapped state can be accessed through the standard dereferencing traits.
+use std::ops::{Deref, DerefMut};
+use uuid::Uuid;
+
+/// A view over an aggregate state and its metadata.
+///
+/// This type combines an aggregate state with information about the
+/// aggregate that owns it, such as its aggregate id.
+///
+/// Aggregate implementations receive an `AggregateView` when handling
+/// commands or applying events, allowing business logic to inspect
+/// aggregate metadata while interacting with the wrapped state as if
+/// it were the state itself.
+///
+/// # Ownership
+///
+/// `AggregateView` is generic over the wrapped value and can therefore
+/// represent either borrowed or owned state:
+///
+/// - `AggregateView<&T>` provides shared access to a state.
+/// - `AggregateView<T>` owns the state.
+///
+/// The wrapped value can be accessed transparently through the standard
+/// dereferencing traits.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AggregateView<S> {
+    aggregate_id: Uuid,
+    inner: S,
+}
+
+impl<S> AggregateView<S> {
+    /// Creates a new aggregate view.
+    ///
+    /// The supplied aggregate id identifies the aggregate that owns the
+    /// wrapped state.    
+    pub const fn new(id: Uuid, inner: S) -> Self {
+        Self {
+            aggregate_id: id,
+            inner,
+        }
+    }
+
+    /// Returns the id of the aggregate that owns the wrapped state.
+    pub const fn id(&self) -> &Uuid {
+        &self.aggregate_id
+    }
+
+    /// Consumes the view and returns the wrapped state.
+    pub fn into_inner(self) -> S {
+        self.inner
+    }
+}
+
+/// Dereferences to the wrapped state.
+///
+/// This allows an `AggregateView<T>` to be used in most places where `T` is expected.
+impl<S> Deref for AggregateView<S> {
+    type Target = S;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+/// Mutably dereferences to the wrapped state.
+///
+/// This allows mutation of the wrapped state when the underlying value
+/// supports mutable access.
+impl<S> DerefMut for AggregateView<S> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}

--- a/tests/aggregate/mod.rs
+++ b/tests/aggregate/mod.rs
@@ -1,4 +1,4 @@
-use esrs::{Aggregate, AggregateContext};
+use esrs::{Aggregate, AggregateView};
 pub use event_handler::*;
 pub use structs::*;
 #[cfg(feature = "postgres")]
@@ -29,14 +29,17 @@ impl Aggregate for TestAggregate {
     type Event = TestEvent;
     type Error = TestError;
 
-    fn handle_command(_state: &Self::State, command: Self::Command) -> Result<Vec<Self::Event>, Self::Error> {
+    fn handle_command(
+        _state: AggregateView<&Self::State>,
+        command: Self::Command,
+    ) -> Result<Vec<Self::Event>, Self::Error> {
         match command {
             TestCommand::Single => Ok(vec![TestEvent { add: 1 }]),
             TestCommand::Multi => Ok(vec![TestEvent { add: 1 }, TestEvent { add: 1 }]),
         }
     }
 
-    fn apply_event(state: Self::State, payload: Self::Event, _ctx: AggregateContext) -> Self::State {
+    fn apply_event(state: AggregateView<Self::State>, payload: Self::Event) -> Self::State {
         Self::State {
             count: state.count + payload.add,
         }

--- a/tests/aggregate/mod.rs
+++ b/tests/aggregate/mod.rs
@@ -1,4 +1,4 @@
-use esrs::Aggregate;
+use esrs::{Aggregate, AggregateContext};
 pub use event_handler::*;
 pub use structs::*;
 #[cfg(feature = "postgres")]
@@ -36,7 +36,7 @@ impl Aggregate for TestAggregate {
         }
     }
 
-    fn apply_event(state: Self::State, payload: Self::Event) -> Self::State {
+    fn apply_event(state: Self::State, payload: Self::Event, _ctx: AggregateContext) -> Self::State {
         Self::State {
             count: state.count + payload.add,
         }


### PR DESCRIPTION
I've recently had the need to know what was the aggregate ID when reconstructing the state of my aggregate from the events, and so I thought that having the possibility of accessing aggregate metadata such as its ID when applying the events or handling a command would be useful.

The goal of this PR is to introduce a solution that has the least impact possible.

I've implemented an `AggregateView` type which wraps the `Self::State` type in the `Aggregate` trait and provides a `Deref` implementation into `Self::State` so users won't have to refactor the way they access the state fields.

For reference about my specific use case, you can see this [PR](https://github.com/primait/policy-management-es/pull/473)